### PR TITLE
Update CLAUDE.md workflow and clean up .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,11 @@
-NEXTAUTH_SECRET=
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+# Supabase Auth
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
-ADMIN_KEY=
-SCRAPE_URL=
-RANKINGS_SCRAPE_URL= 
+# Database (Supabase PostgreSQL - via Prisma)
+DATABASE_URL="postgresql://postgres:password@db.xxxxx.supabase.co:6543/postgres?pgbouncer=true"
+DIRECT_URL="postgresql://postgres:password@db.xxxxx.supabase.co:5432/postgres"
 
-EMAIL_SERVER_HOST=
-EMAIL_SERVER_PORT=
-EMAIL_SERVER_USER=
-EMAIL_SERVER_PASSWORD=
-EMAIL_FROM=
-
-NEXTAUTH_URL=
-
-DATABASE_URL="postgresql://postgres:fxNHfjTyRGslxYp5@db.qvdlbwqghcktezemqbrw.supabase.co:5432/postgres"
+# ESPN Scraping
+SCRAPE_URL=https://www.espn.com/golf/leaderboard/_/tournamentId
+RANKINGS_SCRAPE_URL=https://www.espn.com/golf/rankings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,14 @@ Server Components fetch data via tRPC server caller (`lib/trpc/server.ts`). Clie
 - All code should be readable and debuggable by a human
 - Server Components by default; `'use client'` only for interactive parts
 - Strong preference for readable code over minimalistic abstractions
+
+## Git Workflow
+
+All new work should follow this branching strategy:
+
+1. Pull down the latest from `main`
+2. Create a feature branch off of `main` (e.g. `feat/my-feature`, `fix/bug-name`, `chore/cleanup-task`)
+3. Do your work on the feature branch
+4. When done, submit a PR to `main`
+
+**At the start of a new session**, before beginning any work, prompt the user: **"Pull down main and create a new feature branch?"** — unless we are already mid-session with work in progress on an existing branch.


### PR DESCRIPTION
## Summary
- Added **Git Workflow** section to `CLAUDE.md` documenting the branching strategy (feature branches off `main`, PRs back to `main`) and a session-start prompt reminder
- Cleaned up root `.env.example` — removed 10 legacy env vars from the pre-Supabase era (NextAuth, email provider, ADMIN_KEY) and replaced a hardcoded database connection string with a placeholder template

## Removed env vars
| Variable | Reason |
|---|---|
| `NEXTAUTH_SECRET` | Replaced by Supabase Auth |
| `NEXTAUTH_URL` | Replaced by Supabase Auth |
| `GOOGLE_CLIENT_ID` | Now handled by Supabase OAuth |
| `GOOGLE_CLIENT_SECRET` | Now handled by Supabase OAuth |
| `ADMIN_KEY` | Not referenced in code |
| `EMAIL_SERVER_HOST` | Replaced by Supabase Email OTP |
| `EMAIL_SERVER_PORT` | Replaced by Supabase Email OTP |
| `EMAIL_SERVER_USER` | Replaced by Supabase Email OTP |
| `EMAIL_SERVER_PASSWORD` | Replaced by Supabase Email OTP |
| `EMAIL_FROM` | Replaced by Supabase Email OTP |

## Test plan
- [ ] Verify `apps/web/.env.example` still matches what's needed for local dev
- [ ] Confirm no code references the removed env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)