### PR TITLE
Fix 504 gateway timeouts on scrape endpoints

### DIFF
--- a/apps/web/src/app/api/scrape/rankings/route.ts
+++ b/apps/web/src/app/api/scrape/rankings/route.ts
@@ -1,4 +1,5 @@
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 
 import { NextResponse } from "next/server";
 import { prisma } from "@pool-picks/db";
@@ -34,23 +35,14 @@ async function updateAthleteRankings(parsedAthletes: Athlete[]) {
     throw new Error("No athlete data available!");
   }
 
-  const chunkSize = 10;
-  for (let i = 0; i < parsedAthletes.length; i += chunkSize) {
-    const chunk = parsedAthletes.slice(i, i + chunkSize);
-    await Promise.all(
-      chunk.map(async (athlete) => {
-        const existing = await prisma.athlete.findUnique({
-          where: { full_name: athlete.full_name },
-        });
-        if (existing) {
-          await prisma.athlete.update({
-            where: { full_name: existing.full_name },
-            data: { ranking: athlete.ranking },
-          });
-        }
+  await Promise.all(
+    parsedAthletes.map((athlete) =>
+      prisma.athlete.updateMany({
+        where: { full_name: athlete.full_name },
+        data: { ranking: athlete.ranking },
       })
-    );
-  }
+    )
+  );
 }
 
 export async function POST() {


### PR DESCRIPTION
## Summary
- Add `maxDuration = 60` route segment config to all 4 scrape API routes to extend Vercel's serverless function timeout from the default (10-15s) to 60s
- Replace sequential/chunked DB queries with parallel `Promise.all` + Prisma `upsert` calls, reducing hundreds of sequential queries to fully parallel atomic operations
- Fix UI error handling for non-JSON error responses (504 returns HTML, not JSON) — now shows user-friendly messages like "Request timed out" instead of `Unexpected token 'A'...`

## Test plan
- [ ] Deploy to Vercel and run Sync Tournament Schedule — should complete without 504
- [ ] Run Update Rankings, Update Field, and Update Scores on a tournament — verify no timeouts
- [ ] Trigger a timeout (e.g. throttle network) and verify the UI shows a friendly error message
- [ ] Verify success messages display in green after successful scrape operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)