### PR TITLE
Reorganize pool list and move Create a Pool to navbar

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ interface HeaderProps {
 
 export function Header({ userEmail, isAdmin }: HeaderProps) {
   const [isLoading, setLoading] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const router = useRouter();
   const supabase = createClient();
 
@@ -25,41 +26,100 @@ export function Header({ userEmail, isAdmin }: HeaderProps) {
 
   return (
     <header className="body-font bg-green-500">
-      <div className="container mx-auto flex flex-wrap p-5 md:flex-row justify-between">
+      <div className="container mx-auto flex flex-wrap p-5 justify-between items-center">
         <Link
           href="/"
-          className="flex title-font font-medium items-center md:mb-0"
+          className="flex title-font font-medium items-center"
         >
           <span className="pr-2 text-2xl">&#9971;</span>
           <h3>PoolPicks</h3>
         </Link>
-        <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
+
+        {/* Desktop nav */}
+        {userEmail && (
+          <nav className="hidden md:flex items-center space-x-2">
+            <Link
+              href="/pool/create"
+              className="rounded bg-green-300 hover:bg-yellow hover:text-black px-4 py-2"
+            >
+              Create a Pool
+            </Link>
+            {isAdmin && (
+              <Link
+                href="/system-admin"
+                className="rounded bg-green-300 hover:bg-yellow hover:text-black px-4 py-2"
+              >
+                Admin
+              </Link>
+            )}
+            <button
+              className="rounded bg-green-300 hover:bg-yellow px-4 py-2"
+              onClick={handleSignOut}
+            >
+              {isLoading ? (
+                <span className="flex items-center justify-center">
+                  <Spinner className="w-6 h-6 mr-1" />
+                </span>
+              ) : (
+                <span>Logout</span>
+              )}
+            </button>
+          </nav>
+        )}
+
+        {/* Mobile hamburger button */}
+        {userEmail && (
+          <button
+            className="md:hidden flex flex-col justify-center items-center w-8 h-8 space-y-1"
+            onClick={() => setMenuOpen(!menuOpen)}
+            aria-label="Toggle menu"
+          >
+            <span
+              className={`block w-5 h-0.5 bg-black transition-transform ${menuOpen ? "rotate-45 translate-y-1.5" : ""}`}
+            />
+            <span
+              className={`block w-5 h-0.5 bg-black transition-opacity ${menuOpen ? "opacity-0" : ""}`}
+            />
+            <span
+              className={`block w-5 h-0.5 bg-black transition-transform ${menuOpen ? "-rotate-45 -translate-y-1.5" : ""}`}
+            />
+          </button>
+        )}
+      </div>
+
+      {/* Mobile menu */}
+      {userEmail && menuOpen && (
+        <nav className="md:hidden border-t border-green-300 px-5 pb-4 flex flex-col space-y-2">
+          <Link
+            href="/pool/create"
+            className="rounded bg-green-300 hover:bg-yellow hover:text-black px-4 py-2 text-center"
+            onClick={() => setMenuOpen(false)}
+          >
+            Create a Pool
+          </Link>
           {isAdmin && (
             <Link
               href="/system-admin"
-              className="rounded bg-green-300 hover:bg-yellow hover:text-black mr-2 ml-2 px-4 py-2"
+              className="rounded bg-green-300 hover:bg-yellow hover:text-black px-4 py-2 text-center"
+              onClick={() => setMenuOpen(false)}
             >
               Admin
             </Link>
           )}
-          {userEmail && (
-            <div className="flex items-center space-x-5">
-              <button
-                className="rounded bg-green-300 hover:bg-yellow px-4 py-2"
-                onClick={handleSignOut}
-              >
-                {isLoading ? (
-                  <span className="flex items-center justify-center">
-                    <Spinner className="w-6 h-6 mr-1" />
-                  </span>
-                ) : (
-                  <span>Logout</span>
-                )}
-              </button>
-            </div>
-          )}
+          <button
+            className="rounded bg-green-300 hover:bg-yellow px-4 py-2"
+            onClick={handleSignOut}
+          >
+            {isLoading ? (
+              <span className="flex items-center justify-center">
+                <Spinner className="w-6 h-6 mr-1" />
+              </span>
+            ) : (
+              <span>Logout</span>
+            )}
+          </button>
         </nav>
-      </div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/pool/InviteActions.tsx
+++ b/apps/web/src/components/pool/InviteActions.tsx
@@ -34,6 +34,26 @@ interface InviteActionsProps {
   userEmail: string;
 }
 
+const STATUS_GROUP_ORDER = ["Active", "Locked", "Open", "Setup"] as const;
+
+const STATUS_LABELS: Record<string, string> = {
+  Active: "Active",
+  Locked: "Locked",
+  Open: "Open",
+  Setup: "Setup",
+  Complete: "Completed",
+};
+
+function groupPoolsByStatus(pools: PoolMembership[]) {
+  const groups: Record<string, PoolMembership[]> = {};
+  for (const member of pools) {
+    const status = member.pool.status;
+    if (!groups[status]) groups[status] = [];
+    groups[status].push(member);
+  }
+  return groups;
+}
+
 export function InviteActions({
   initialInvites,
   poolMembers,
@@ -41,6 +61,7 @@ export function InviteActions({
 }: InviteActionsProps) {
   const [poolInvites, setPoolInvites] = useState(initialInvites);
   const [loadingButtonId, setLoadingButtonId] = useState<string | null>(null);
+  const [completedOpen, setCompletedOpen] = useState(false);
   const router = useRouter();
 
   const updateInviteStatus = trpc.poolInvite.updateStatus.useMutation({
@@ -59,10 +80,7 @@ export function InviteActions({
     },
   });
 
-  const handleInvite = (
-    invite: Invite,
-    status: string
-  ) => {
+  const handleInvite = (invite: Invite, status: string) => {
     const buttonId = `${invite.id}-${status === "Accepted" ? "accept" : "reject"}`;
     setLoadingButtonId(buttonId);
     updateInviteStatus.mutate({
@@ -74,15 +92,26 @@ export function InviteActions({
     });
   };
 
+  const grouped = groupPoolsByStatus(poolMembers);
+  const completedPools = grouped["Complete"] || [];
+  const hasActivePools = STATUS_GROUP_ORDER.some(
+    (s) => grouped[s] && grouped[s].length > 0
+  );
+
   return (
     <div className="container max-w-xl mx-auto flex flex-wrap items-center flex-col bg-black">
-      <div className="w-full p-6 rounded bg-grey-100 text-white text-xs">
-        <p className="text-center font-bold">PoolPicks</p>
-        <p className="text-center">
-          Create a pool or accept an invitation to get started.
-        </p>
-      </div>
       <div className="flex flex-col justify-center items-center flex-wrap rounded bg-grey-200 w-full mt-4 pt-8 px-6 text-white">
+        {/* Create a Pool — top */}
+        <div className="w-full flex justify-center pb-6">
+          <Link
+            href="/pool/create"
+            className="rounded bg-green-500 text-black font-medium px-6 py-2 hover:bg-green-300"
+          >
+            Create a Pool
+          </Link>
+        </div>
+
+        {/* Pending Invites */}
         {poolInvites.map((invite) => (
           <div
             className="p-4 bg-yellow w-full rounded mb-6 text-black"
@@ -126,41 +155,93 @@ export function InviteActions({
           </div>
         ))}
 
-        {!poolMembers.length && !poolInvites.length && (
+        {/* Empty state */}
+        {!hasActivePools && !poolInvites.length && !completedPools.length && (
           <p className="text-center pb-8">
-            You currently aren't in any active pools. Create one or ask a
+            You currently aren&apos;t in any active pools. Create one or ask a
             commissioner to invite you!
           </p>
         )}
 
-        {poolMembers.map((member) => (
-          <div
-            className="p-4 mb-6 bg-grey-100 w-full rounded"
-            key={member.id}
-          >
-            <div className="text-center">
-              <h3 className="mb-2">{member.pool.name}</h3>
-              <p className="mb-4">{member.pool.status}</p>
-              <div className="flex flex-wrap justify-center">
-                <Link
-                  href={`/pool/${member.pool.id}`}
-                  className="rounded bg-grey-200 hover:bg-yellow hover:text-black px-4 py-2"
+        {/* Pool groups by status */}
+        {STATUS_GROUP_ORDER.map((status) => {
+          const pools = grouped[status];
+          if (!pools || pools.length === 0) return null;
+          return (
+            <div key={status} className="w-full mb-2">
+              <h4 className="text-grey-75 text-xs uppercase tracking-wider mb-3">
+                {STATUS_LABELS[status]}
+              </h4>
+              {pools.map((member) => (
+                <div
+                  className="p-4 mb-4 bg-grey-100 w-full rounded"
+                  key={member.id}
                 >
-                  Go To Pool
-                </Link>
-              </div>
+                  <div className="text-center">
+                    <h3 className="mb-2">{member.pool.name}</h3>
+                    <div className="flex flex-wrap justify-center">
+                      <Link
+                        href={`/pool/${member.pool.id}`}
+                        className="rounded bg-grey-200 hover:bg-yellow hover:text-black px-4 py-2"
+                      >
+                        Go To Pool
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
-          </div>
-        ))}
+          );
+        })}
 
-        <div className="w-full flex justify-center pb-6">
-          <Link
-            href="/pool/create"
-            className="rounded bg-green-500 text-black font-medium px-6 py-2 hover:bg-green-300"
-          >
-            Create a Pool
-          </Link>
-        </div>
+        {/* Completed pools accordion */}
+        {completedPools.length > 0 && (
+          <div className="-mx-6 w-[calc(100%+3rem)] mb-6 overflow-hidden">
+            <button
+              onClick={() => setCompletedOpen(!completedOpen)}
+              className="w-full flex items-center justify-between px-6 py-3 text-left bg-grey-200 hover:bg-grey-75 transition-colors"
+            >
+              <h4 className="text-xs uppercase tracking-wider text-grey-50">
+                Completed ({completedPools.length})
+              </h4>
+              <svg
+                className={`w-4 h-4 text-grey-50 transform transition-transform ${completedOpen ? "" : "rotate-180"}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+            {completedOpen && (
+              <div className="bg-grey-200 px-6 pb-4 pt-2">
+                {completedPools.map((member, index) => (
+                  <div
+                    className={`p-4 bg-grey-100 w-full rounded ${index < completedPools.length - 1 ? "mb-4" : ""}`}
+                    key={member.id}
+                  >
+                    <div className="text-center">
+                      <h3 className="mb-2">{member.pool.name}</h3>
+                      <div className="flex flex-wrap justify-center">
+                        <Link
+                          href={`/pool/${member.pool.id}`}
+                          className="rounded bg-grey-200 hover:bg-yellow hover:text-black px-4 py-2"
+                        >
+                          Go To Pool
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/pool/InviteActions.tsx
+++ b/apps/web/src/components/pool/InviteActions.tsx
@@ -101,16 +101,6 @@ export function InviteActions({
   return (
     <div className="container max-w-xl mx-auto flex flex-wrap items-center flex-col bg-black">
       <div className="flex flex-col justify-center items-center flex-wrap rounded bg-grey-200 w-full mt-4 pt-8 px-6 text-white">
-        {/* Create a Pool — top */}
-        <div className="w-full flex justify-center pb-6">
-          <Link
-            href="/pool/create"
-            className="rounded bg-green-500 text-black font-medium px-6 py-2 hover:bg-green-300"
-          >
-            Create a Pool
-          </Link>
-        </div>
-
         {/* Pending Invites */}
         {poolInvites.map((invite) => (
           <div

--- a/apps/web/src/components/pool/InviteActions.tsx
+++ b/apps/web/src/components/pool/InviteActions.tsx
@@ -189,13 +189,13 @@ export function InviteActions({
           <div className="-mx-6 w-[calc(100%+3rem)] mb-6 overflow-hidden">
             <button
               onClick={() => setCompletedOpen(!completedOpen)}
-              className="w-full flex items-center justify-between px-6 py-3 text-left bg-grey-200 hover:bg-grey-75 transition-colors"
+              className="group w-full flex items-center justify-between px-6 py-3 text-left bg-grey-200"
             >
-              <h4 className="text-xs uppercase tracking-wider text-grey-50">
+              <h4 className="text-xs uppercase tracking-wider text-grey-75">
                 Completed ({completedPools.length})
               </h4>
               <svg
-                className={`w-4 h-4 text-grey-50 transform transition-transform ${completedOpen ? "" : "rotate-180"}`}
+                className={`w-4 h-4 transition-transform transform group-hover:text-white ${completedOpen ? "text-white" : "text-grey-75 rotate-180"}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- **Reorganize pool list**: Group pools by status (Active, Locked, Open, Setup) with a collapsible accordion for completed pools
- **Move Create a Pool to navbar**: Relocated the button into the header nav, positioned left of the Admin button
- **Mobile hamburger menu**: All nav buttons collapse into an animated hamburger menu on mobile
- **Completed accordion styling**: Matched text color to other status headers, caret turns white on hover and when accordion is open

## Test plan
- [ ] Verify pool list groups by status correctly on the home page
- [ ] Verify completed pools accordion expands/collapses with caret color transitions
- [ ] Verify "Create a Pool" button appears in navbar on desktop
- [ ] Verify Admin button still conditionally renders for admin users
- [ ] Verify hamburger menu works on mobile viewports
- [ ] Verify non-authenticated users don't see nav buttons or hamburger

🤖 Generated with [Claude Code](https://claude.com/claude-code)