### PR TITLE
Fix magic link auth cookie issue

### DIFF
--- a/apps/web/src/app/api/auth/sign-out/route.ts
+++ b/apps/web/src/app/api/auth/sign-out/route.ts
@@ -1,0 +1,10 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/route";
+
+export async function POST() {
+  const supabase = createRouteHandlerClient();
+  await supabase.auth.signOut();
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,29 +1,53 @@
 export const dynamic = "force-dynamic";
 
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { prisma } from "@pool-picks/db";
-import { createRouteHandlerClient } from "@/lib/supabase/route";
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type");
   const next = searchParams.get("next") ?? "/";
 
-  const supabase = createRouteHandlerClient();
+  // Build the redirect response first so the Supabase client can set cookies on it
+  const redirectUrl = new URL(next, origin);
+  const response = NextResponse.redirect(redirectUrl);
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
   let user = null;
 
   if (code) {
-    // OAuth flow (Google)
+    // OAuth flow (Google) — PKCE verifier is in cookies, don't clear them
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) console.error("OAuth exchange error:", error.message);
     if (!error && data.user) user = data.user;
   } else if (tokenHash && type === "magiclink") {
-    // Magic link flow — verify the hashed token directly
+    // Clear any stale session before verifying — prevents conflicts when
+    // switching between OAuth and magic link auth methods
+    await supabase.auth.signOut();
     const { data, error } = await supabase.auth.verifyOtp({
       token_hash: tokenHash,
       type: "magiclink",
     });
+    if (error) console.error("Magic link verify error:", error.message);
     if (!error && data.user) user = data.user;
   }
 
@@ -38,8 +62,8 @@ export async function GET(request: Request) {
       },
     });
 
-    return NextResponse.redirect(`${origin}${next}`);
+    return response;
   }
 
-  return NextResponse.redirect(`${origin}/auth/sign-in?error=auth`);
+  return NextResponse.redirect(new URL("/auth/sign-in?error=auth", origin));
 }

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -19,6 +19,8 @@ export function Header({ userEmail, isAdmin }: HeaderProps) {
 
   const handleSignOut = async () => {
     setLoading(true);
+    // Sign out server-side first to properly clear cookies
+    await fetch("/api/auth/sign-out", { method: "POST" });
     await supabase.auth.signOut();
     router.push("/auth/sign-in");
     router.refresh();


### PR DESCRIPTION
## Summary
- Fix auth callback to set session cookies directly on the redirect response instead of using `cookies()` from `next/headers`, which was losing cookies on redirect
- Clear stale sessions before magic link verification to prevent conflicts when switching between OAuth and magic link auth
- Add server-side sign-out route (`/api/auth/sign-out`) to properly clear auth cookies
- Add error logging for auth verification failures

## Test plan
- [ ] Sign in with Google OAuth
- [ ] Sign out, then sign in with magic link (different email)
- [ ] Sign out, then sign in with Google OAuth again
- [ ] Verify magic link works on first click without "expired" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)