### PR TITLE
Add ESPN API schema validation with email alerts

### DIFF
--- a/apps/web/src/app/api/scrape/espn-validation.ts
+++ b/apps/web/src/app/api/scrape/espn-validation.ts
@@ -1,0 +1,209 @@
+import { Resend } from "resend";
+
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// --- Validators ---
+
+export function validateScoreboardResponse(data: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(data?.events)) {
+    errors.push("Missing or non-array: data.events");
+    return { valid: false, errors };
+  }
+
+  const event = data.events[0];
+  if (!event) {
+    errors.push("Empty events array");
+    return { valid: false, errors };
+  }
+
+  if (typeof event.id !== "string") {
+    errors.push(`Expected event.id to be string, got ${typeof event.id}`);
+  }
+
+  const competition = event.competitions?.[0];
+  if (!competition) {
+    errors.push("Missing: event.competitions[0]");
+    return { valid: false, errors };
+  }
+
+  if (!competition.status?.type?.state) {
+    errors.push("Missing: competition.status.type.state");
+  }
+
+  const competitors = competition.competitors;
+  if (!Array.isArray(competitors)) {
+    errors.push("Missing or non-array: competition.competitors");
+    return { valid: false, errors };
+  }
+
+  // Validate shape of first competitor with data
+  const sample = competitors[0];
+  if (sample) {
+    if (typeof sample.athlete?.fullName !== "string") {
+      errors.push(
+        `Expected competitor.athlete.fullName to be string, got ${typeof sample.athlete?.fullName}`
+      );
+    }
+    if (typeof sample.score !== "string") {
+      errors.push(
+        `Expected competitor.score to be string, got ${typeof sample.score}`
+      );
+    }
+    if (typeof sample.order !== "number") {
+      errors.push(
+        `Expected competitor.order to be number, got ${typeof sample.order}`
+      );
+    }
+    if (!Array.isArray(sample.linescores)) {
+      errors.push("Missing or non-array: competitor.linescores");
+    } else if (sample.linescores.length > 0) {
+      const ls = sample.linescores[0];
+      if (typeof ls.period !== "number") {
+        errors.push(
+          `Expected linescore.period to be number, got ${typeof ls.period}`
+        );
+      }
+      if (typeof ls.value !== "number") {
+        errors.push(
+          `Expected linescore.value to be number, got ${typeof ls.value}`
+        );
+      }
+      if (typeof ls.displayValue !== "string") {
+        errors.push(
+          `Expected linescore.displayValue to be string, got ${typeof ls.displayValue}`
+        );
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateScheduleResponse(data: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(data?.events)) {
+    errors.push("Missing or non-array: data.events");
+    return { valid: false, errors };
+  }
+
+  const sample = data.events[0];
+  if (sample) {
+    if (typeof sample.id !== "string") {
+      errors.push(
+        `Expected event.id to be string, got ${typeof sample.id}`
+      );
+    }
+    if (typeof sample.name !== "string" && typeof sample.shortName !== "string") {
+      errors.push("Missing: event.name and event.shortName");
+    }
+    if (typeof sample.date !== "string") {
+      errors.push(
+        `Expected event.date to be string, got ${typeof sample.date}`
+      );
+    }
+    if (typeof sample.endDate !== "string") {
+      errors.push(
+        `Expected event.endDate to be string, got ${typeof sample.endDate}`
+      );
+    }
+    if (!sample.status?.type?.name) {
+      errors.push("Missing: event.status.type.name");
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateEventDetailsResponse(data: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(data?.courses)) {
+    errors.push("Missing or non-array: data.courses");
+    return { valid: false, errors };
+  }
+
+  const sample = data.courses[0];
+  if (sample) {
+    if (typeof sample.name !== "string") {
+      errors.push(
+        `Expected course.name to be string, got ${typeof sample.name}`
+      );
+    }
+    if (typeof sample.address?.city !== "string") {
+      errors.push(
+        `Expected course.address.city to be string, got ${typeof sample.address?.city}`
+      );
+    }
+    if (typeof sample.address?.state !== "string") {
+      errors.push(
+        `Expected course.address.state to be string, got ${typeof sample.address?.state}`
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// --- Alert Email ---
+
+export async function sendSchemaAlert(
+  endpoint: string,
+  errors: string[]
+): Promise<void> {
+  const alertEmail = process.env.ADMIN_ALERT_EMAIL;
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromAddress = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+
+  if (!alertEmail || !apiKey) {
+    console.error(
+      "Cannot send schema alert — ADMIN_ALERT_EMAIL or RESEND_API_KEY not set"
+    );
+    return;
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    await resend.emails.send({
+      from: `Pool Picks Alerts <${fromAddress}>`,
+      to: alertEmail,
+      subject: "Pool Picks: ESPN API schema change detected",
+      html: `
+        <h2>ESPN API Schema Change Detected</h2>
+        <p><strong>Endpoint:</strong> ${endpoint}</p>
+        <p><strong>Time:</strong> ${new Date().toISOString()}</p>
+        <p><strong>Validation errors:</strong></p>
+        <ul>${errors.map((e) => `<li>${e}</li>`).join("")}</ul>
+        <p>The ESPN JSON API response no longer matches the expected shape. Score syncing is broken until the parsing code is updated.</p>
+      `,
+    });
+  } catch (err) {
+    console.error("Failed to send schema alert email:", err);
+  }
+}
+
+// --- Convenience wrapper ---
+
+export async function assertValidResponse(
+  data: any,
+  validator: (data: any) => ValidationResult,
+  endpointLabel: string
+): Promise<void> {
+  const result = validator(data);
+  if (!result.valid) {
+    console.error(
+      `ESPN schema validation failed for ${endpointLabel}:`,
+      result.errors
+    );
+    // Fire-and-forget — don't block the response on email delivery
+    sendSchemaAlert(endpointLabel, result.errors);
+    throw new Error(
+      "ESPN API response format has changed. The admin has been notified."
+    );
+  }
+}

--- a/apps/web/src/app/api/scrape/schedule/route.ts
+++ b/apps/web/src/app/api/scrape/schedule/route.ts
@@ -4,6 +4,11 @@ export const maxDuration = 60;
 import { NextResponse, type NextRequest } from "next/server";
 import { prisma } from "@pool-picks/db";
 import { createRouteHandlerClient } from "@/lib/supabase/route";
+import {
+  assertValidResponse,
+  validateScheduleResponse,
+  validateEventDetailsResponse,
+} from "../espn-validation";
 
 const ESPN_SCOREBOARD_API =
   "https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard";
@@ -28,6 +33,12 @@ async function fetchEventDetails(
     if (!response.ok) return { course: "", city: "", region: "" };
 
     const data = await response.json();
+    const detailsValidation = validateEventDetailsResponse(data);
+    if (!detailsValidation.valid) {
+      console.warn(`Event details validation failed for ${eventId}:`, detailsValidation.errors);
+      return { course: "", city: "", region: "" };
+    }
+
     const courseData = data.courses?.[0];
     if (!courseData) return { course: "", city: "", region: "" };
 
@@ -48,6 +59,8 @@ async function fetchSchedule(year: number): Promise<ParsedTournament[]> {
     throw new Error(`ESPN API returned ${response.status}`);
 
   const data = await response.json();
+  await assertValidResponse(data, validateScheduleResponse, "scoreboard (schedule)");
+
   const events = data.events || [];
   const tournaments: ParsedTournament[] = [];
 

--- a/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
@@ -4,6 +4,10 @@ export const maxDuration = 60;
 import { NextResponse } from "next/server";
 import { prisma } from "@pool-picks/db";
 import { createRouteHandlerClient } from "@/lib/supabase/route";
+import {
+  assertValidResponse,
+  validateScoreboardResponse,
+} from "../../../espn-validation";
 
 const ESPN_API_BASE =
   "https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard";
@@ -25,8 +29,9 @@ async function fetchAthleteField(id: string): Promise<Athlete[]> {
     throw new Error(`ESPN API returned ${response.status}`);
 
   const data = await response.json();
-  const event = data.events?.[0];
-  if (!event) throw new Error("No event data returned from ESPN API.");
+  await assertValidResponse(data, validateScoreboardResponse, "scoreboard (athletes)");
+
+  const event = data.events[0];
 
   // ESPN silently returns the most recent event when the requested event
   // doesn't have data yet. Verify we got the right one.

--- a/apps/web/src/app/api/scrape/tournaments/[id]/scores/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/scores/route.ts
@@ -4,6 +4,10 @@ export const maxDuration = 60;
 import { NextResponse } from "next/server";
 import { prisma } from "@pool-picks/db";
 import { createRouteHandlerClient } from "@/lib/supabase/route";
+import {
+  assertValidResponse,
+  validateScoreboardResponse,
+} from "../../../espn-validation";
 
 const ESPN_API_BASE =
   "https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard";
@@ -126,8 +130,9 @@ async function fetchGolfData(id: string) {
     throw new Error(`ESPN API returned ${response.status}`);
 
   const data = await response.json();
-  const event = data.events?.[0];
-  if (!event) throw new Error("No event data returned from ESPN API.");
+  await assertValidResponse(data, validateScoreboardResponse, "scoreboard (scores)");
+
+  const event = data.events[0];
 
   // ESPN silently returns the most recent event when the requested event
   // doesn't have data yet. Verify we got the right one.


### PR DESCRIPTION
## Summary
- Validates ESPN JSON API response shapes before parsing in all scrape routes (scores, athletes, schedule)
- If ESPN changes their API structure, syncing fails with a clear user-facing error
- Sends an alert email to `ADMIN_ALERT_EMAIL` via Resend with the specific validation errors
- Event details validation (venue/course) is soft — warns and falls back to empty strings

## Setup
Add `ADMIN_ALERT_EMAIL=murph.grainger@gmail.com` to Vercel env vars.

## Test plan
- [ ] Verify scores/athletes/schedule sync still works normally (validation passes on current ESPN responses)
- [ ] Verify alert email sends when validation fails (can temporarily break a field check to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)