### PR TITLE
Fix Prisma connection pool timeout in scrape routes

### DIFF
--- a/apps/web/src/app/api/scrape/rankings/route.ts
+++ b/apps/web/src/app/api/scrape/rankings/route.ts
@@ -45,22 +45,25 @@ async function updateAthleteRankings(parsedAthletes: Athlete[]) {
   let notFound = 0;
   const missingNames: string[] = [];
 
-  await Promise.all(
-    parsedAthletes.map(async (athlete) => {
-      const result = await prisma.athlete.updateMany({
-        where: { full_name: athlete.full_name },
-        data: { ranking: athlete.ranking },
-      });
-      if (result.count > 0) {
-        updated++;
-      } else {
-        notFound++;
-        if (missingNames.length < 10) {
-          missingNames.push(athlete.full_name);
+  const BATCH_SIZE = 5;
+  for (let i = 0; i < parsedAthletes.length; i += BATCH_SIZE) {
+    await Promise.all(
+      parsedAthletes.slice(i, i + BATCH_SIZE).map(async (athlete) => {
+        const result = await prisma.athlete.updateMany({
+          where: { full_name: athlete.full_name },
+          data: { ranking: athlete.ranking },
+        });
+        if (result.count > 0) {
+          updated++;
+        } else {
+          notFound++;
+          if (missingNames.length < 10) {
+            missingNames.push(athlete.full_name);
+          }
         }
-      }
-    })
-  );
+      })
+    );
+  }
 
   return { updated, notFound, missingNames };
 }

--- a/apps/web/src/app/api/scrape/schedule/route.ts
+++ b/apps/web/src/app/api/scrape/schedule/route.ts
@@ -104,33 +104,38 @@ async function fetchSchedule(year: number): Promise<ParsedTournament[]> {
 }
 
 async function upsertTournaments(tournaments: ParsedTournament[]) {
-  const results = await Promise.all(
-    tournaments.map((t) =>
-      prisma.tournament.upsert({
-        where: { external_id: t.external_id },
-        update: {
-          name: t.name,
-          course: t.course,
-          city: t.city,
-          region: t.region,
-          start_date: t.start_date,
-          end_date: t.end_date,
-        },
-        create: {
-          name: t.name,
-          external_id: t.external_id,
-          course: t.course,
-          city: t.city,
-          region: t.region,
-          start_date: t.start_date,
-          end_date: t.end_date,
-          status: "Scheduled",
-        },
-      })
-    )
-  );
+  let total = 0;
+  const BATCH_SIZE = 5;
+  for (let i = 0; i < tournaments.length; i += BATCH_SIZE) {
+    await Promise.all(
+      tournaments.slice(i, i + BATCH_SIZE).map((t) =>
+        prisma.tournament.upsert({
+          where: { external_id: t.external_id },
+          update: {
+            name: t.name,
+            course: t.course,
+            city: t.city,
+            region: t.region,
+            start_date: t.start_date,
+            end_date: t.end_date,
+          },
+          create: {
+            name: t.name,
+            external_id: t.external_id,
+            course: t.course,
+            city: t.city,
+            region: t.region,
+            start_date: t.start_date,
+            end_date: t.end_date,
+            status: "Scheduled",
+          },
+        })
+      )
+    );
+    total += Math.min(BATCH_SIZE, tournaments.length - i);
+  }
 
-  return { total: results.length };
+  return { total };
 }
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
@@ -75,29 +75,32 @@ async function updateAthleteField(
     throw new Error("No athlete data available for this tournament!");
   }
 
-  await Promise.all(
-    parsedAthletes.map(async (athlete) => {
-      const existingAthlete = await prisma.athlete.upsert({
-        where: { full_name: athlete.full_name },
-        create: { full_name: athlete.full_name },
-        update: {},
-      });
+  const BATCH_SIZE = 5;
+  for (let i = 0; i < parsedAthletes.length; i += BATCH_SIZE) {
+    await Promise.all(
+      parsedAthletes.slice(i, i + BATCH_SIZE).map(async (athlete) => {
+        const existingAthlete = await prisma.athlete.upsert({
+          where: { full_name: athlete.full_name },
+          create: { full_name: athlete.full_name },
+          update: {},
+        });
 
-      await prisma.athletesInTournaments.upsert({
-        where: {
-          tournament_id_athlete_id: {
+        await prisma.athletesInTournaments.upsert({
+          where: {
+            tournament_id_athlete_id: {
+              tournament_id: tournamentId,
+              athlete_id: existingAthlete.id,
+            },
+          },
+          create: {
             tournament_id: tournamentId,
             athlete_id: existingAthlete.id,
           },
-        },
-        create: {
-          tournament_id: tournamentId,
-          athlete_id: existingAthlete.id,
-        },
-        update: {},
-      });
-    })
-  );
+          update: {},
+        });
+      })
+    );
+  }
 }
 
 export async function POST(

--- a/apps/web/src/app/api/scrape/tournaments/[id]/scores/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/scores/route.ts
@@ -218,43 +218,46 @@ async function updateGolfData(
   if (!parsedAthleteData.length)
     throw new Error("No data available for this tournament!");
 
-  await Promise.all(
-    parsedAthleteData.map(async (athleteData) => {
-      const existingAthlete = await prisma.athlete.upsert({
-        where: { full_name: athleteData.full_name },
-        create: { full_name: athleteData.full_name },
-        update: {},
-      });
+  const BATCH_SIZE = 5;
+  for (let i = 0; i < parsedAthleteData.length; i += BATCH_SIZE) {
+    await Promise.all(
+      parsedAthleteData.slice(i, i + BATCH_SIZE).map(async (athleteData) => {
+        const existingAthlete = await prisma.athlete.upsert({
+          where: { full_name: athleteData.full_name },
+          create: { full_name: athleteData.full_name },
+          update: {},
+        });
 
-      const scoreData = {
-        score_round_one: athleteData.score_round_one,
-        score_round_two: athleteData.score_round_two,
-        score_round_three: athleteData.score_round_three,
-        score_round_four: athleteData.score_round_four,
-        score_sum: athleteData.score_sum,
-        score_under_par: athleteData.score_under_par,
-        score_today: athleteData.score_today,
-        position: athleteData.position,
-        thru: athleteData.thru,
-        status: athleteData.status,
-      };
+        const scoreData = {
+          score_round_one: athleteData.score_round_one,
+          score_round_two: athleteData.score_round_two,
+          score_round_three: athleteData.score_round_three,
+          score_round_four: athleteData.score_round_four,
+          score_sum: athleteData.score_sum,
+          score_under_par: athleteData.score_under_par,
+          score_today: athleteData.score_today,
+          position: athleteData.position,
+          thru: athleteData.thru,
+          status: athleteData.status,
+        };
 
-      await prisma.athletesInTournaments.upsert({
-        where: {
-          tournament_id_athlete_id: {
+        await prisma.athletesInTournaments.upsert({
+          where: {
+            tournament_id_athlete_id: {
+              tournament_id: tournamentId,
+              athlete_id: existingAthlete.id,
+            },
+          },
+          create: {
             tournament_id: tournamentId,
             athlete_id: existingAthlete.id,
+            ...scoreData,
           },
-        },
-        create: {
-          tournament_id: tournamentId,
-          athlete_id: existingAthlete.id,
-          ...scoreData,
-        },
-        update: scoreData,
-      });
-    })
-  );
+          update: scoreData,
+        });
+      })
+    );
+  }
 
   if (parsedTournamentData?.cut_line) {
     await prisma.tournament.update({


### PR DESCRIPTION
## Summary
- Batches concurrent Prisma upserts into groups of 5 across all four scrape route handlers (rankings, schedule, athletes, scores)
- Previously, all upserts fired at once via `Promise.all()`, exhausting the connection pool (limit 5, timeout 10s) when processing 150+ athletes

## Test plan
- [ ] Trigger "Sync Field" for an upcoming tournament from the admin page
- [ ] Trigger "Sync Scores" for an active tournament
- [ ] Trigger "Sync Rankings" from the admin page
- [ ] Verify no connection pool timeout errors in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)