### PR TITLE
fix turbo cache for prisma schema changes

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "../../packages/db/prisma/**"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {


### PR DESCRIPTION
Include prisma schema and migrations as build inputs so Turbo invalidates the cache when the schema changes across deploys.