### PR TITLE
ensure prisma generate runs on every build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",
-    "build": "[ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || prisma migrate deploy --schema=../../packages/db/prisma/schema.prisma && next build",
+    "build": "prisma generate --schema=../../packages/db/prisma/schema.prisma && ([ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || prisma migrate deploy --schema=../../packages/db/prisma/schema.prisma) && next build",
     "start": "next start",
     "postinstall": "prisma generate --schema=../../packages/db/prisma/schema.prisma"
   },


### PR DESCRIPTION
The build was using a stale Prisma client from Turbo cache, causing P2022 errors for the join_mode column in production. Running prisma generate before next build ensures the client always matches the current schema.