### PR TITLE
fix: pass env vars through Turborepo for production migrations

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["*"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Turborepo was filtering out `DIRECT_URL` (and other env vars) during builds because they weren't declared in `turbo.json`
- This caused `prisma migrate deploy` to be skipped on every Vercel deployment (`Skipping migrations (no DIRECT_URL)`)
- Added `globalPassThroughEnv: ["*"]` so all env vars are available to build tasks without maintaining an explicit list

## Test plan
- [ ] Merge and deploy — verify build logs show `prisma migrate deploy` running instead of `Skipping migrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)