### PR TITLE
Email improvements, lock modal, homepage cards, pool config

### DIFF
--- a/apps/web/src/app/api/feature-request/route.ts
+++ b/apps/web/src/app/api/feature-request/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/route";
+import { Resend } from "resend";
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { message } = await request.json();
+
+  if (!message || typeof message !== "string" || message.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Message is required" },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromAddress = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+  const devEmail = process.env.ADMIN_ALERT_EMAIL || fromAddress;
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Email service not configured" },
+      { status: 500 },
+    );
+  }
+
+  const resend = new Resend(apiKey);
+
+  try {
+    await resend.emails.send({
+      from: `PoolPicks <${fromAddress}>`,
+      to: devEmail,
+      subject: "PoolPicks Feature Request",
+      html: `
+<h2>Feature Request from ${user.email}</h2>
+<p><strong>User:</strong> ${user.email}</p>
+<p><strong>Message:</strong></p>
+<p>${message.replace(/\n/g, "<br>")}</p>
+      `.trim(),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to send request" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,6 +3,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
 body {
   min-height: 100vh;
   display: flex;

--- a/apps/web/src/app/pool/create/page.tsx
+++ b/apps/web/src/app/pool/create/page.tsx
@@ -24,6 +24,136 @@ function formatDateRange(start: Date, end: Date): string {
   return `${startStr} - ${endStr}`;
 }
 
+function ConfigInfoPopover({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div className="mt-2 p-3 bg-white border border-grey-100 rounded-lg shadow-lg text-sm text-grey-75">
+      <p className="font-bold text-black mb-2">Pick 6, Count 4</p>
+      <ul className="space-y-1">
+        <li>- Pick 6 players for the tournament</li>
+        <li>- Max 3 picks from the A Group (top 20 OWGR)</li>
+        <li>- Your best 4 scores count toward your total</li>
+        <li>- Lowest total score wins</li>
+        <li>- DQ if fewer than 4 players make the cut</li>
+      </ul>
+      <div
+        onClick={onToggle}
+        className="mt-3 text-sm text-green-700 hover:text-green-900 font-bold cursor-pointer"
+      >
+        Got it
+      </div>
+    </div>
+  );
+}
+
+function FeatureRequestModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+    setSending(true);
+    try {
+      const res = await fetch("/api/feature-request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+      });
+      if (res.ok) {
+        setSent(true);
+        setMessage("");
+      } else {
+        toast.error("Failed to send request. Please try again.");
+      }
+    } catch {
+      toast.error("Failed to send request. Please try again.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+      <div className="bg-white rounded-lg p-6 max-w-sm mx-4 shadow-xl w-full">
+        {sent ? (
+          <>
+            <h3 className="text-lg font-bold mb-3">Request Sent</h3>
+            <p className="text-sm text-grey-75 mb-4">
+              Thanks for the feedback! We&apos;ll review your request and
+              consider it for a future update.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setSent(false);
+                onClose();
+              }}
+              className="w-full px-4 py-2 rounded bg-green-700 hover:bg-green-900 text-white font-medium"
+            >
+              Done
+            </button>
+          </>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <h3 className="text-lg font-bold mb-3">Request a Configuration</h3>
+            <p className="text-sm text-grey-75 mb-4">
+              Describe the pool configuration you&apos;d like to see. For
+              example: number of picks, scoring rules, group restrictions, etc.
+            </p>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="e.g. Pick 4, Count 3 with no group restrictions..."
+              rows={4}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm mb-4"
+            />
+            <div className="flex flex-col space-y-2">
+              <button
+                type="submit"
+                disabled={sending || !message.trim()}
+                className="w-full px-4 py-2 rounded bg-green-700 hover:bg-green-900 text-white font-medium disabled:opacity-50"
+              >
+                {sending ? (
+                  <span className="flex items-center justify-center">
+                    <Spinner className="w-4 h-4 mr-2" />
+                    Sending...
+                  </span>
+                ) : (
+                  "Send Request"
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={sending}
+                className="w-full px-4 py-2 rounded text-grey-75 hover:text-black"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function PoolCreatePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -39,6 +169,10 @@ export default function PoolCreatePage() {
     end_date: Date;
   } | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const configDropdownRef = useRef<HTMLDivElement>(null);
+  const [showFeatureRequest, setShowFeatureRequest] = useState(false);
+  const [showConfigInfo, setShowConfigInfo] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
 
   const {
     register,
@@ -77,6 +211,12 @@ export default function PoolCreatePage() {
         !dropdownRef.current.contains(e.target as Node)
       ) {
         setIsOpen(false);
+      }
+      if (
+        configDropdownRef.current &&
+        !configDropdownRef.current.contains(e.target as Node)
+      ) {
+        setConfigOpen(false);
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
@@ -186,6 +326,62 @@ export default function PoolCreatePage() {
           )}
         </div>
 
+        {/* Pool Configuration */}
+        <div className="block" ref={configDropdownRef}>
+          <span>Pool Configuration</span>
+          <button
+            type="button"
+            onClick={() => setConfigOpen(!configOpen)}
+            className="mt-1 flex items-center justify-between w-full rounded-md border border-gray-300 shadow-sm bg-white px-3 py-2 text-left"
+          >
+            <div className="flex items-center gap-2">
+              <span>Pick 6, Count 4</span>
+              <span
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowConfigInfo(!showConfigInfo);
+                }}
+                className="inline-flex items-center justify-center text-grey-75 hover:text-black transition-colors cursor-pointer"
+                aria-label="Learn about this configuration"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </span>
+            </div>
+            <svg className={`w-4 h-4 text-grey-75 transition-transform ${configOpen ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {configOpen && (
+            <ul className="mt-1 rounded-md bg-white border border-grey-300 shadow-lg overflow-hidden">
+              <li
+                onClick={() => setConfigOpen(false)}
+                className="px-3 py-2 cursor-pointer bg-grey-200 font-medium"
+              >
+                Pick 6, Count 4
+              </li>
+              <li
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfigOpen(false);
+                  setShowFeatureRequest(true);
+                }}
+                className="px-3 py-2 cursor-pointer hover:bg-grey-200 text-sm text-grey-75 border-t border-grey-100"
+              >
+                More configurations coming soon.{" "}
+                <span className="text-green-700 font-medium underline">
+                  Request a new one
+                </span>
+              </li>
+            </ul>
+          )}
+          <ConfigInfoPopover
+            open={showConfigInfo}
+            onToggle={() => setShowConfigInfo(false)}
+          />
+        </div>
+
         <label className="block">
           <span>Entry Amount</span>
           <div className="relative mt-1">
@@ -265,6 +461,11 @@ export default function PoolCreatePage() {
           )}
         </button>
       </form>
+
+      <FeatureRequestModal
+        open={showFeatureRequest}
+        onClose={() => setShowFeatureRequest(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/system-admin/tournament/[id]/page.tsx
+++ b/apps/web/src/app/system-admin/tournament/[id]/page.tsx
@@ -22,12 +22,18 @@ export default function TournamentAdminPage() {
   const params = useParams();
   const id = Number(params?.id);
 
+  const utils = trpc.useUtils();
+
   const { data: tournament, isLoading: tournamentLoading } =
     trpc.tournament.getById.useQuery({ id });
 
   const tournamentHealth = trpc.tournament.getHealth.useQuery({ id });
 
-  const updateTournament = trpc.tournament.updateStatus.useMutation();
+  const updateTournament = trpc.tournament.updateStatus.useMutation({
+    onSuccess: () => {
+      utils.tournament.getById.invalidate({ id });
+    },
+  });
 
   const [selectedOption, setSelectedOption] = useState<SelectValues>({
     value: "",

--- a/apps/web/src/components/admin/TournamentList.tsx
+++ b/apps/web/src/components/admin/TournamentList.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { formatTournamentDates, resolveTournamentStatus } from "@pool-picks/utils";
+import { formatTournamentDates, resolveTournamentStatus, getTournamentStatus } from "@pool-picks/utils";
 import { SyncScheduleButton } from "./SyncScheduleButton";
 
 interface Pool {
@@ -211,7 +211,7 @@ function TournamentCard({
 }) {
   const [pastOpen, setPastOpen] = useState(false);
 
-  const resolved = resolveTournamentStatus(tournament);
+  const displayStatus = getTournamentStatus(tournament.start_date, tournament.end_date);
 
   return (
     <li className="bg-white border border-grey-100 rounded-lg shadow-sm p-3 mb-2">
@@ -228,9 +228,9 @@ function TournamentCard({
               {formatTournamentDates(tournament.start_date, tournament.end_date)}
             </p>
             <span
-              className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusColor(resolved)}`}
+              className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusColor(displayStatus)}`}
             >
-              {resolved}
+              {displayStatus}
             </span>
           </div>
         </div>

--- a/apps/web/src/components/picks/PicksCreateForm.tsx
+++ b/apps/web/src/components/picks/PicksCreateForm.tsx
@@ -148,7 +148,7 @@ export function PicksCreateForm({
       >
         <h3>{isEditing ? "Edit Your Picks" : "Submit Your Picks"}</h3>
         <ul className="list-none text-lg">
-          <span className="font-bold">Pick 6, Use 4</span>
+          <span className="font-bold">Pick 6, Count 4</span>
           <li>- Pick 3 players max from the A Group</li>
           <li>- The A Group is the players in the top 20 OWGR</li>
           <li>- The lowest 4 of your 6 player scores is your total score</li>

--- a/apps/web/src/components/pool/InviteActions.tsx
+++ b/apps/web/src/components/pool/InviteActions.tsx
@@ -10,6 +10,7 @@ import {
   ordinalSuffix,
   resolveTournamentStatus,
   getEffectivePoolPhase,
+  PICKS_PER_MEMBER,
   type PoolPhase,
 } from "@pool-picks/utils";
 import { Spinner } from "@/components/ui/Spinner";
@@ -31,6 +32,8 @@ interface PoolMembership {
   rank: number | null;
   score: number | null;
   isTied: boolean;
+  picksCount: number;
+  memberCount: number;
   pool: {
     id: number;
     name: string;
@@ -123,52 +126,91 @@ function ChevronRight({ className }: { className?: string }) {
 function PoolCard({ member }: { member: PoolMembership }) {
   const phase = getMemberPhase(member);
   const showScore = phase === "live" || phase === "completed";
+  const hasPicks = member.picksCount === PICKS_PER_MEMBER;
 
   return (
     <Link
       href={`/pool/${member.pool.id}`}
-      className="flex items-center justify-between p-3 mb-2 bg-white border border-grey-100 rounded shadow-sm hover:shadow-md transition-shadow group"
+      className="block p-4 mb-2 bg-white border border-grey-100 rounded shadow-sm hover:shadow-md transition-shadow group"
     >
-      <div className="min-w-0">
-        <div className="flex items-center gap-2">
-          <p className="font-bold text-black">{member.pool.name}</p>
-          {member.role === "COMMISSIONER" && (
-            <span className="relative group/tip inline-flex items-center">
-              <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gold/20 text-yellow text-[10px] leading-none font-bold cursor-default">
-                C
+      <div className="flex items-start justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="font-bold text-black">{member.pool.name}</p>
+            {member.role === "COMMISSIONER" && (
+              <span className="relative group/tip inline-flex items-center">
+                <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gold/20 text-yellow text-[10px] leading-none font-bold cursor-default">
+                  C
+                </span>
+                <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 rounded bg-green-700 text-white text-[10px] whitespace-nowrap opacity-0 pointer-events-none group-hover/tip:opacity-100 transition-opacity">
+                  Commissioner
+                </span>
               </span>
-              <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 rounded bg-green-700 text-white text-[10px] whitespace-nowrap opacity-0 pointer-events-none group-hover/tip:opacity-100 transition-opacity">
-                Commissioner
-              </span>
-            </span>
-          )}
+            )}
+          </div>
+          <p className="text-sm text-grey-75 mt-0.5">
+            {member.pool.tournament.name}
+          </p>
         </div>
-        <p className="text-sm text-grey-75 mt-1">
+        <ChevronRight className="w-5 h-5 text-grey-300 group-hover:text-green-700 shrink-0 ml-2 mt-1" />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-xs text-grey-75">
+        <span>
           {formatTournamentDates(
             member.pool.tournament.start_date,
-            member.pool.tournament.end_date
+            member.pool.tournament.end_date,
           )}
-        </p>
-        {showScore && member.rank !== null && (
-          <div className="flex items-center gap-4 mt-2 text-sm">
-            <div>
-              <span className="text-grey-75 text-xs">Rank </span>
-              <span className="font-bold text-green-700">
-                {member.isTied ? "T" : ""}
-                {member.rank}
-                {ordinalSuffix(member.rank)}
-              </span>
-            </div>
-            <div>
-              <span className="text-grey-75 text-xs">Score </span>
-              <span className="font-bold text-green-700">
-                {formatToPar(member.score ?? null) ?? "\u2014"}
-              </span>
-            </div>
-          </div>
+        </span>
+        <span>{member.memberCount} members</span>
+        {member.pool.amount_entry > 0 && (
+          <span>${member.pool.amount_entry} entry</span>
         )}
       </div>
-      <ChevronRight className="w-5 h-5 text-grey-300 group-hover:text-green-700 shrink-0 ml-2" />
+
+      {/* Live / Completed: show rank and score */}
+      {showScore && member.rank !== null && (
+        <div className="flex items-center gap-4 mt-3 pt-3 border-t border-grey-100 text-sm">
+          <div>
+            <span className="text-grey-75 text-xs">Rank </span>
+            <span className="font-bold text-green-700">
+              {member.isTied ? "T" : ""}
+              {member.rank}
+              {ordinalSuffix(member.rank)}
+            </span>
+          </div>
+          <div>
+            <span className="text-grey-75 text-xs">Score </span>
+            <span className="font-bold text-green-700">
+              {formatToPar(member.score ?? null) ?? "\u2014"}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Open: show pick status */}
+      {phase === "open" && (
+        <div className="mt-3 pt-3 border-t border-grey-100">
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded ${
+              hasPicks
+                ? "bg-green-100 text-green-700"
+                : "bg-gold/20 text-yellow"
+            }`}
+          >
+            {hasPicks ? "Picks submitted" : "Picks needed"}
+          </span>
+        </div>
+      )}
+
+      {/* Locked-awaiting: show picks locked message */}
+      {phase === "locked-awaiting" && (
+        <div className="mt-3 pt-3 border-t border-grey-100">
+          <span className="text-xs text-grey-75">
+            Picks locked — waiting for tournament to start
+          </span>
+        </div>
+      )}
     </Link>
   );
 }

--- a/apps/web/src/components/pool/PoolAdminPanel.tsx
+++ b/apps/web/src/components/pool/PoolAdminPanel.tsx
@@ -91,7 +91,7 @@ export function PoolAdminPanel({
   const handleStatusChange = async (option: SelectValues | null) => {
     if (!option) return;
 
-    if (option.value === "Open" && currentStatus === "Setup") {
+    if (option.value === "Open" || option.value === "Locked") {
       setPendingStatus(option.value);
       setShowConfirmModal(true);
       return;
@@ -101,12 +101,18 @@ export function PoolAdminPanel({
     updatePool.mutate({
       pool_id: poolId,
       status: option.value as "Setup" | "Open" | "Locked" | "Complete",
+      notify: false,
     });
   };
 
-  const confirmOpen = (notify: boolean) => {
+  const confirmStatusChange = (notify: boolean) => {
+    if (!pendingStatus) return;
     setPendingNotify(notify);
-    updatePool.mutate({ pool_id: poolId, status: "Open", notify });
+    updatePool.mutate({
+      pool_id: poolId,
+      status: pendingStatus as "Setup" | "Open" | "Locked" | "Complete",
+      notify,
+    });
   };
 
   const poolStatuses = ["Setup", "Open", "Locked", "Complete"];
@@ -264,50 +270,67 @@ export function PoolAdminPanel({
       {showConfirmModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
           <div className="bg-white rounded-lg p-6 max-w-sm mx-4 shadow-xl">
-            <h3 className="text-lg font-bold mb-3">Open this pool?</h3>
-            <p className="text-sm text-grey-75 mb-4">
-              Opening the pool allows members to make their picks. You can also
-              notify the following invitees by email:
-            </p>
-            {existingInviteEmails.length > 0 && (
-              <ul className="text-xs text-grey-75 mb-6 space-y-1">
-                {existingInviteEmails.map((email) => (
-                  <li key={email}>{email}</li>
-                ))}
-              </ul>
-            )}
-            {existingInviteEmails.length === 0 && (
-              <p className="text-xs text-grey-75 italic mb-6">
-                No pending invites.
-              </p>
+            {pendingStatus === "Open" ? (
+              <>
+                <h3 className="text-lg font-bold mb-3">Open this pool?</h3>
+                <p className="text-sm text-grey-75 mb-4">
+                  Opening the pool allows members to make their picks. You can
+                  also notify the following invitees by email:
+                </p>
+                {existingInviteEmails.length > 0 && (
+                  <ul className="text-xs text-grey-75 mb-6 space-y-1">
+                    {existingInviteEmails.map((email) => (
+                      <li key={email}>{email}</li>
+                    ))}
+                  </ul>
+                )}
+                {existingInviteEmails.length === 0 && (
+                  <p className="text-xs text-grey-75 italic mb-6">
+                    No pending invites.
+                  </p>
+                )}
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-bold mb-3">Lock this pool?</h3>
+                <p className="text-sm text-grey-75 mb-4">
+                  Locking the pool finalizes all picks. Members will be able to
+                  see who everyone picked. You can notify all pool members by
+                  email.
+                </p>
+              </>
             )}
             <div className="flex flex-col space-y-2">
               <button
-                onClick={() => confirmOpen(true)}
+                onClick={() => confirmStatusChange(true)}
                 disabled={updatePool.isPending}
                 className="w-full px-4 py-2 rounded bg-green-700 hover:bg-green-900 text-white font-medium"
               >
                 {updatePool.isPending && pendingNotify === true ? (
                   <span className="flex items-center justify-center">
                     <Spinner className="w-4 h-4 mr-2" />
-                    Opening...
+                    {pendingStatus === "Open" ? "Opening..." : "Locking..."}
                   </span>
-                ) : (
+                ) : pendingStatus === "Open" ? (
                   "Open & Notify"
+                ) : (
+                  "Lock & Notify"
                 )}
               </button>
               <button
-                onClick={() => confirmOpen(false)}
+                onClick={() => confirmStatusChange(false)}
                 disabled={updatePool.isPending}
                 className="w-full px-4 py-2 rounded bg-grey-100 hover:bg-grey-300"
               >
                 {updatePool.isPending && pendingNotify === false ? (
                   <span className="flex items-center justify-center">
                     <Spinner className="w-4 h-4 mr-2" />
-                    Opening...
+                    {pendingStatus === "Open" ? "Opening..." : "Locking..."}
                   </span>
-                ) : (
+                ) : pendingStatus === "Open" ? (
                   "Open Without Notifying"
+                ) : (
+                  "Lock Without Notifying"
                 )}
               </button>
               <button

--- a/packages/api/src/lib/email.ts
+++ b/packages/api/src/lib/email.ts
@@ -8,7 +8,7 @@ function getResendClient(): Resend {
   return new Resend(apiKey);
 }
 
-function buildEmailWrapper(content: string): string {
+function buildEmailWrapper(content: string, preheader: string): string {
   return `
 <!DOCTYPE html>
 <html>
@@ -17,6 +17,9 @@ function buildEmailWrapper(content: string): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body style="margin:0;padding:0;background-color:#f5f5f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <div style="display:none;font-size:1px;color:#f5f5f5;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">
+    ${preheader}
+  </div>
   <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:40px 20px;">
     <tr>
       <td align="center">
@@ -105,7 +108,10 @@ ${buildButton(`${appBaseUrl}/join/${inviteCode}`, "View Invitation")}`;
       from: `PoolPicks <${fromAddress}>`,
       to,
       subject: `You've been invited to join ${poolName} on PoolPicks`,
-      html: buildEmailWrapper(content),
+      html: buildEmailWrapper(
+        content,
+        `You've been invited to join ${poolName} for the ${tournamentName} (${tournamentDates}).`,
+      ),
     });
     return { success: true };
   } catch (err) {
@@ -147,7 +153,10 @@ export async function sendOtpEmail({
       from: `PoolPicks <${fromAddress}>`,
       to,
       subject: "Your PoolPicks sign-in code",
-      html: buildEmailWrapper(content),
+      html: buildEmailWrapper(
+        content,
+        `Your PoolPicks sign-in code is ${otp}. It expires in 10 minutes.`,
+      ),
     });
     return { success: true };
   } catch (err) {
@@ -181,7 +190,10 @@ export async function sendPoolAutoCompleteEmail({
   tournamentName,
   appBaseUrl,
   poolId,
-}: SendPoolAutoCompleteEmailParams): Promise<{ success: boolean; error?: string }> {
+}: SendPoolAutoCompleteEmailParams): Promise<{
+  success: boolean;
+  error?: string;
+}> {
   const fromAddress = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
   const poolUrl = `${appBaseUrl}/pool/${poolId}`;
 
@@ -201,7 +213,10 @@ ${buildButton(poolUrl, "View Results")}`;
       from: `PoolPicks <${fromAddress}>`,
       to,
       subject: `${poolName} has been automatically completed`,
-      html: buildEmailWrapper(content),
+      html: buildEmailWrapper(
+        content,
+        `${poolName} (${tournamentName}) has been automatically completed. View the final results.`,
+      ),
     });
     return { success: true };
   } catch (err) {
@@ -237,7 +252,56 @@ ${buildButton(poolUrl, "Make Your Picks")}`;
       from: `PoolPicks <${fromAddress}>`,
       to,
       subject: `${poolName} is open — time to make your picks!`,
-      html: buildEmailWrapper(content),
+      html: buildEmailWrapper(
+        content,
+        `The field for ${poolName} has been finalized. Make your picks before the pool is locked!`,
+      ),
+    });
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown email error";
+    return { success: false, error: message };
+  }
+}
+
+// --- Pool Locked Notification Email ---
+
+interface SendPoolLockedEmailParams {
+  to: string;
+  poolName: string;
+  appBaseUrl: string;
+  poolId: number;
+}
+
+export async function sendPoolLockedEmail({
+  to,
+  poolName,
+  appBaseUrl,
+  poolId,
+}: SendPoolLockedEmailParams): Promise<{ success: boolean; error?: string }> {
+  const fromAddress = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+  const poolUrl = `${appBaseUrl}/pool/${poolId}`;
+
+  const content = `
+<h2 style="margin:0 0 16px;color:#181818;font-size:20px;">Picks are locked in!</h2>
+<p style="margin:0 0 8px;color:#333333;font-size:16px;line-height:1.5;">
+  <strong>${poolName}</strong> has been locked by the commissioner.
+</p>
+<p style="margin:0 0 32px;color:#555555;font-size:14px;line-height:1.5;">
+  All picks are final. Head over to the pool to see who everyone picked.
+</p>
+${buildButton(poolUrl, "View All Picks")}`;
+
+  try {
+    const resend = getResendClient();
+    await resend.emails.send({
+      from: `PoolPicks <${fromAddress}>`,
+      to,
+      subject: `${poolName} is locked — see who everyone picked!`,
+      html: buildEmailWrapper(
+        content,
+        `${poolName} has been locked. All picks are final — see who everyone picked!`,
+      ),
     });
     return { success: true };
   } catch (err) {

--- a/packages/api/src/routers/pool.ts
+++ b/packages/api/src/routers/pool.ts
@@ -7,7 +7,11 @@ import {
   protectedProcedure,
   commissionerProcedure,
 } from "../trpc";
-import { sendPoolOpenEmail, sendPoolAutoCompleteEmail } from "../lib/email";
+import {
+  sendPoolOpenEmail,
+  sendPoolAutoCompleteEmail,
+  sendPoolLockedEmail,
+} from "../lib/email";
 import { generateUniqueInviteCode } from "../lib/inviteCode";
 
 const STALE_POOL_DAYS = 7;
@@ -289,6 +293,49 @@ export const poolRouter = router({
             if (failed.length > 0) {
               console.error(
                 `Failed to send ${failed.length} pool-open emails for pool ${input.pool_id}`
+              );
+            }
+          });
+        }
+
+        return updated;
+      }
+
+      // When moving to Locked, optionally notify all pool members
+      if (input.status === "Locked") {
+        const pool = await prisma.pool.findUnique({
+          where: { id: input.pool_id },
+          select: { name: true },
+        });
+
+        const updated = await prisma.pool.update({
+          where: { id: input.pool_id },
+          data: { status: input.status },
+        });
+
+        if (input.notify && pool) {
+          const members = await prisma.poolMember.findMany({
+            where: { pool_id: input.pool_id },
+            select: { user: { select: { email: true } } },
+          });
+
+          const appBaseUrl =
+            process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+          Promise.allSettled(
+            members.map((m) =>
+              sendPoolLockedEmail({
+                to: m.user.email,
+                poolName: pool.name,
+                appBaseUrl,
+                poolId: input.pool_id,
+              })
+            )
+          ).then((results) => {
+            const failed = results.filter((r) => r.status === "rejected");
+            if (failed.length > 0) {
+              console.error(
+                `Failed to send ${failed.length} pool-locked emails for pool ${input.pool_id}`
               );
             }
           });

--- a/packages/api/src/routers/poolMember.ts
+++ b/packages/api/src/routers/poolMember.ts
@@ -160,7 +160,13 @@ export const poolMemberRouter = router({
                 status: true,
               },
             },
+            _count: {
+              select: { pool_members: true },
+            },
           },
+        },
+        athletes: {
+          select: { athlete_id: true },
         },
         user: {
           select: { email: true },
@@ -248,7 +254,12 @@ export const poolMemberRouter = router({
     }
 
     return memberships.map((m) => ({
-      ...m,
+      id: m.id,
+      role: m.role,
+      pool: m.pool,
+      user: m.user,
+      picksCount: m.athletes.length,
+      memberCount: m.pool._count.pool_members,
       ...(rankMap[m.id] ?? { rank: null, score: null, isTied: false }),
     }));
   }),


### PR DESCRIPTION
## Summary
- **Email preheaders**: All emails now include hidden preview text for Gmail/Outlook
- **Pool locked email**: New email alert when commissioner locks a pool, telling members picks are final and they can see everyone's picks
- **Lock confirmation modal**: Commissioner sees a modal (like the Open modal) when locking a pool with "Lock & Notify" / "Lock Without Notifying" options
- **Notify safety**: Modal always shown for Open/Locked transitions regardless of starting status; other transitions pass `notify: false` to prevent accidental emails
- **Homepage pool cards**: Richer cards showing tournament name, dates, member count, entry fee, pick status (open pools), and locked state
- **Pool Configuration field**: New "Pick 6, Count 4" selector on pool create page with info popover explaining the rules
- **Feature request form**: Users can request new pool configurations via a modal form that emails the developer (uses ADMIN_ALERT_EMAIL)
- **Naming**: Renamed "Pick 6, Use 4" to "Pick 6, Count 4" across the app

## Test plan
- [ ] Create a pool and verify the Pool Configuration field shows with info icon and dropdown
- [ ] Click info icon to see rules popover, click "Got it" to dismiss
- [ ] Open config dropdown and click "Request a new one" to verify feature request modal sends email
- [ ] Change pool status to Open and verify modal appears with notify options
- [ ] Change pool status to Locked and verify lock modal appears
- [ ] Flip a Locked pool back to Open and verify modal still appears (not auto-sending)
- [ ] Check email preview text in Gmail for invite, OTP, open, and locked emails
- [ ] Verify homepage pool cards show tournament name, member count, entry fee
- [ ] Verify open pool cards show "Picks needed" / "Picks submitted" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)