### PR TITLE
fix: ESPN API URL for scheduled tournament fields

### DIFF
--- a/apps/web/src/app/api/scrape/espn-validation.ts
+++ b/apps/web/src/app/api/scrape/espn-validation.ts
@@ -7,25 +7,15 @@ interface ValidationResult {
 
 // --- Validators ---
 
-export function validateScoreboardResponse(data: any): ValidationResult {
+// Validates a single event object (already unwrapped from events[] if needed)
+export function validateScoreboardResponse(event: any): ValidationResult {
   const errors: string[] = [];
 
-  if (!Array.isArray(data?.events)) {
-    errors.push("Missing or non-array: data.events");
-    return { valid: false, errors };
+  if (typeof event?.id !== "string") {
+    errors.push(`Expected event.id to be string, got ${typeof event?.id}`);
   }
 
-  const event = data.events[0];
-  if (!event) {
-    errors.push("Empty events array");
-    return { valid: false, errors };
-  }
-
-  if (typeof event.id !== "string") {
-    errors.push(`Expected event.id to be string, got ${typeof event.id}`);
-  }
-
-  const competition = event.competitions?.[0];
+  const competition = event?.competitions?.[0];
   if (!competition) {
     errors.push("Missing: event.competitions[0]");
     return { valid: false, errors };
@@ -78,6 +68,38 @@ export function validateScoreboardResponse(data: any): ValidationResult {
           `Expected linescore.displayValue to be string, got ${typeof ls.displayValue}`
         );
       }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// Lighter validator for field/athlete updates — no score or linescore checks
+export function validateFieldResponse(event: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof event?.id !== "string") {
+    errors.push(`Expected event.id to be string, got ${typeof event?.id}`);
+  }
+
+  const competition = event?.competitions?.[0];
+  if (!competition) {
+    errors.push("Missing: event.competitions[0]");
+    return { valid: false, errors };
+  }
+
+  const competitors = competition.competitors;
+  if (!Array.isArray(competitors)) {
+    errors.push("Missing or non-array: competition.competitors");
+    return { valid: false, errors };
+  }
+
+  const sample = competitors[0];
+  if (sample) {
+    if (typeof sample.athlete?.fullName !== "string") {
+      errors.push(
+        `Expected competitor.athlete.fullName to be string, got ${typeof sample.athlete?.fullName}`
+      );
     }
   }
 

--- a/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
@@ -6,7 +6,7 @@ import { prisma } from "@pool-picks/db";
 import { createRouteHandlerClient } from "@/lib/supabase/route";
 import {
   assertValidResponse,
-  validateScoreboardResponse,
+  validateFieldResponse,
 } from "../../../espn-validation";
 
 const ESPN_API_BASE =
@@ -23,18 +23,16 @@ async function fetchAthleteField(id: string): Promise<Athlete[]> {
   if (!tournament || !tournament.external_id)
     throw new Error("Invalid tournament ID requested.");
 
-  const url = `${ESPN_API_BASE}?event=${tournament.external_id}`;
+  const url = `${ESPN_API_BASE}/${tournament.external_id}`;
   const response = await fetch(url);
   if (!response.ok)
     throw new Error(`ESPN API returned ${response.status}`);
 
-  const data = await response.json();
-  await assertValidResponse(data, validateScoreboardResponse, "scoreboard (athletes)");
+  const raw = await response.json();
+  // Path-based URL returns the event directly; query-param URL wraps in { events: [...] }
+  const event = raw.events ? raw.events[0] : raw;
+  await assertValidResponse(event, validateFieldResponse, "scoreboard (field)");
 
-  const event = data.events[0];
-
-  // ESPN silently returns the most recent event when the requested event
-  // doesn't have data yet. Verify we got the right one.
   if (event.id !== String(tournament.external_id)) {
     throw new Error(
       "The field for this tournament hasn't been announced yet. Try again closer to the event."

--- a/apps/web/src/app/api/scrape/tournaments/score-sync.ts
+++ b/apps/web/src/app/api/scrape/tournaments/score-sync.ts
@@ -110,18 +110,18 @@ export async function fetchGolfData(id: string) {
   if (!tournament || !tournament.external_id)
     throw new Error("Invalid tournament ID requested.");
 
-  const url = `${ESPN_API_BASE}?event=${tournament.external_id}`;
+  const url = `${ESPN_API_BASE}/${tournament.external_id}`;
   const response = await fetch(url);
   if (!response.ok) throw new Error(`ESPN API returned ${response.status}`);
 
-  const data = await response.json();
+  const raw = await response.json();
+  // Path-based URL returns the event directly; query-param URL wraps in { events: [...] }
+  const event = raw.events ? raw.events[0] : raw;
   await assertValidResponse(
-    data,
+    event,
     validateScoreboardResponse,
     "scoreboard (scores)"
   );
-
-  const event = data.events[0];
 
   if (event.id !== String(tournament.external_id)) {
     const now = new Date();


### PR DESCRIPTION
## Summary
- Switched ESPN scoreboard API from query-param URL (`?event=ID`) to path-based URL (`/ID`) — the query-param version silently returns the most recent completed event when the requested tournament is still scheduled, causing a false "field not live yet" error
- Added `validateFieldResponse` — a lighter validator for field/athlete updates that doesn't require `score` or `linescores` fields (absent on scheduled events)
- Updated `score-sync.ts` with the same URL fix and response unwrapping for consistency

## Test plan
- [x] Verified path-based URL returns correct event for scheduled tournament (Masters 401811941)
- [x] Verified path-based URL returns identical data structure for completed tournament (Valero 401811940)
- [x] Confirmed field update works for The Masters via admin panel
- [ ] Monitor cron score sync during next active tournament to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)