### PR TITLE
fix: run prisma migrations outside turborepo

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",
-    "build": "prisma generate --schema=../../packages/db/prisma/schema.prisma && ([ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || prisma migrate deploy --schema=../../packages/db/prisma/schema.prisma) && next build",
+    "build": "prisma generate --schema=../../packages/db/prisma/schema.prisma && next build",
     "start": "next start",
     "postinstall": "prisma generate --schema=../../packages/db/prisma/schema.prisma"
   },
@@ -28,6 +28,7 @@
     "react-select": "^5.8.0",
     "standardwebhooks": "^1.0.0",
     "superjson": "^2.2.1",
+    "prisma": "^5.22.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
@@ -40,7 +41,6 @@
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
-    "prisma": "^5.22.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.6.0"
   }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "cd ../.. && yarn build",
+  "buildCommand": "cd ../.. && ([ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || npx prisma migrate deploy --schema=packages/db/prisma/schema.prisma) && yarn build",
   "installCommand": "cd ../.. && yarn install",
   "crons": [
     {


### PR DESCRIPTION
## Summary
- Moves `prisma migrate deploy` from the web app's build script into `vercel.json`'s `buildCommand`, where it runs before Turborepo with full env var access
- Simplifies web app build script to just `prisma generate && next build`
- Moves `prisma` from devDependencies to dependencies so Vercel doesn't prune it
- Keeps the `DIRECT_URL` guard so preview deploys without a DB connection skip migrations gracefully

## Why
Turborepo filters env vars from child processes by default. Running migrations inside `turbo build` required `globalPassThroughEnv: ["*"]`, which leaked all env vars into Next.js prerendering and crashed the build. Running migrations before Turborepo in the Vercel build command gives them DB access without affecting Next.js.

## Test plan
- [x] `yarn build` passes locally
- [ ] Verify preview deployment succeeds
- [ ] Merge to production and verify deployment + migrations run

🤖 Generated with [Claude Code](https://claude.com/claude-code)