### PR TITLE
fix: make migration non-blocking during build

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "cd ../.. && ([ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || npx prisma migrate deploy --schema=packages/db/prisma/schema.prisma) && yarn build",
+  "buildCommand": "cd ../.. && ([ -z \"$DIRECT_URL\" ] && echo 'Skipping migrations (no DIRECT_URL)' || npx prisma migrate deploy --schema=packages/db/prisma/schema.prisma || echo 'Migration failed — continuing build') && yarn build",
   "installCommand": "cd ../.. && yarn install",
   "crons": [
     {


### PR DESCRIPTION
Vercel build servers cannot reach Supabase direct connection (port 5432). Make migration best-effort so builds succeed while DB connectivity is resolved. Migrations can be run manually in the meantime.