### PR TITLE
fix: redirect existing members from join link

### DIFF
--- a/apps/web/src/app/join/[code]/page.tsx
+++ b/apps/web/src/app/join/[code]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { prisma } from "@pool-picks/db";
 import { getAuthUser } from "@/lib/supabase/auth";
 import { JoinPoolClient } from "@/components/pool/JoinPoolClient";
@@ -60,6 +60,10 @@ export default async function JoinPage({ params }: JoinPageProps) {
     ]);
     isAlreadyMember = !!membership;
     hasPendingInvite = !!invite;
+
+    if (isAlreadyMember) {
+      redirect(`/pool/${pool.id}`);
+    }
   }
 
   return (
@@ -67,7 +71,6 @@ export default async function JoinPage({ params }: JoinPageProps) {
       pool={pool}
       code={upperCode}
       isAuthenticated={!!supabaseUser}
-      isAlreadyMember={isAlreadyMember}
       hasPendingInvite={hasPendingInvite}
       commissionerNickname={commissionerNickname}
     />

--- a/apps/web/src/components/pool/JoinPoolClient.tsx
+++ b/apps/web/src/components/pool/JoinPoolClient.tsx
@@ -24,7 +24,6 @@ interface JoinPoolClientProps {
   };
   code: string;
   isAuthenticated: boolean;
-  isAlreadyMember: boolean;
   hasPendingInvite: boolean;
   commissionerNickname: string | null;
 }
@@ -33,7 +32,6 @@ export function JoinPoolClient({
   pool,
   code,
   isAuthenticated,
-  isAlreadyMember,
   hasPendingInvite,
   commissionerNickname,
 }: JoinPoolClientProps) {
@@ -95,21 +93,8 @@ export function JoinPoolClient({
           </>
         )}
 
-        {/* Already a member */}
-        {isAuthenticated && isAlreadyMember && (
-          <>
-            <p className="text-grey-75 mb-4">You&apos;re already in this pool!</p>
-            <a
-              href={`/pool/${pool.id}`}
-              className="w-full bg-green-700 text-white hover:bg-green-900 rounded py-3 px-4 text-center block"
-            >
-              Go to Pool
-            </a>
-          </>
-        )}
-
         {/* Can't join */}
-        {isAuthenticated && !isAlreadyMember && !canJoin && (
+        {isAuthenticated && !canJoin && (
           <p className="text-grey-75">
             {!poolAccepting
               ? "This pool is no longer accepting new members."
@@ -118,7 +103,7 @@ export function JoinPoolClient({
         )}
 
         {/* Can join */}
-        {isAuthenticated && !isAlreadyMember && canJoin && (
+        {isAuthenticated && canJoin && (
           <form onSubmit={handleJoin} className="w-full flex flex-col">
             <input
               type="text"


### PR DESCRIPTION
## Summary
- Existing pool members who click a join link are now **server-side redirected** straight to `/pool/{id}` instead of seeing a "You're already in this pool!" page with a "Go to Pool" button
- Removed the `isAlreadyMember` prop and client-side "already a member" UI block since the server handles this case before rendering

## Join page behavior matrix

| User state | Pool state | Result |
|---|---|---|
| **Already a member** (signed in) | Any | Instant redirect to pool page |
| Not signed in | Setup/Open | "Sign In to Join" button |
| Not signed in | Locked/Active/Complete | "No longer accepting members" |
| Signed in, OPEN pool | Setup/Open | Nickname form → join |
| Signed in, INVITE_ONLY, **has invite** | Setup/Open | Nickname form → join |
| Signed in, INVITE_ONLY, **no invite** | Setup/Open | "Invite-only" message |
| Signed in | Locked/Active/Complete | "No longer accepting members" |
| Invalid code | N/A | 404 |

## Test plan
- [ ] Click join link while signed in as an existing member → should redirect to pool page
- [ ] Click join link while signed out → should see "Sign In to Join"
- [ ] Click join link for an open pool while signed in (not a member) → should see nickname form
- [ ] Click join link for invite-only pool without an invite → should see invite-only message

🤖 Generated with [Claude Code](https://claude.com/claude-code)