### PR TITLE
feat: auto-lock pools at midnight PT and fix UI bugs

### DIFF
--- a/apps/web/src/app/api/cron/scores/route.ts
+++ b/apps/web/src/app/api/cron/scores/route.ts
@@ -3,7 +3,10 @@ export const maxDuration = 60;
 
 import { NextResponse } from "next/server";
 import { prisma } from "@pool-picks/db";
-import { autoAdvanceScheduledTournaments } from "@pool-picks/api";
+import {
+  autoAdvanceScheduledTournaments,
+  autoLockPoolsBeforeTournament,
+} from "@pool-picks/api";
 import { sendScoreSyncAlertEmail } from "@pool-picks/api/lib/email";
 import { syncTournamentScores } from "../../scrape/tournaments/score-sync";
 
@@ -15,6 +18,9 @@ export async function GET(request: Request) {
 
   // Auto-advance any Scheduled tournaments whose start_date has passed
   const advanced = await autoAdvanceScheduledTournaments();
+
+  // Auto-lock Open pools whose tournament starts today or earlier (Pacific time)
+  const locked = await autoLockPoolsBeforeTournament();
 
   // Notify admin when score auto-sync turns on
   const adminEmail = process.env.ADMIN_ALERT_EMAIL;
@@ -43,6 +49,7 @@ export async function GET(request: Request) {
       message: "No active tournaments",
       synced: 0,
       failed: 0,
+      poolsLocked: locked.length,
     });
   }
 
@@ -63,6 +70,7 @@ export async function GET(request: Request) {
     message: `Synced ${synced} tournament(s)${failed > 0 ? `, ${failed} failed` : ""}`,
     synced,
     failed,
+    poolsLocked: locked.length,
     errors: errors.length > 0 ? errors : undefined,
   });
 }

--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -121,6 +121,7 @@ export default function SignInPage() {
     }
 
     router.replace(next);
+    router.refresh();
   };
 
   const handleResendOtp = async () => {

--- a/apps/web/src/components/pool/PoolDetailClient.tsx
+++ b/apps/web/src/components/pool/PoolDetailClient.tsx
@@ -71,7 +71,9 @@ export function PoolDetailClient({
 }: PoolDetailClientProps) {
   const router = useRouter();
   const [poolStatus, setPoolStatus] = useState(pool.status);
-  const [showAdminPanel, setShowAdminPanel] = useState(isCommissioner);
+  const [showAdminPanel, setShowAdminPanel] = useState(
+    isCommissioner && pool.status !== "Locked" && pool.status !== "Complete"
+  );
 
   const tournamentStatus = useMemo(
     () => resolveTournamentStatus(pool.tournament),
@@ -84,6 +86,15 @@ export function PoolDetailClient({
   const [updatedPoolMembers, setUpdatedPoolMembers] =
     useState<PoolMemberFormatted[]>(initialPoolMembers);
   const [poolInvites, setPoolInvites] = useState(pool.pool_invites);
+
+  // Sync pool members from server when props change (e.g. after router.refresh())
+  useEffect(() => {
+    setUpdatedPoolMembers(initialPoolMembers);
+  }, [initialPoolMembers]);
+
+  useEffect(() => {
+    setPoolInvites(pool.pool_invites);
+  }, [pool.pool_invites]);
   const [lastRefreshed, setLastRefreshed] = useState<Date>(
     new Date(pool.tournament.updated_at)
   );
@@ -200,8 +211,8 @@ export function PoolDetailClient({
           </div>
         </div>
 
-        {/* Last updated timestamp — only during active tournament */}
-        {phase === "live" && tournamentStatus === "Active" && (
+        {/* Last updated timestamp — only when live with actual scores */}
+        {phase === "live" && tournamentStatus === "Active" && updatedPoolMembers.some(m => m.member_sum_under_par !== null) && (
           <p className="text-xs text-grey-75 mt-4">
             Scores last updated {formatLastRefreshed()}
             {showUpdateIndicator && (

--- a/apps/web/src/components/pool/PoolMemberCard.tsx
+++ b/apps/web/src/components/pool/PoolMemberCard.tsx
@@ -183,11 +183,13 @@ export function PoolMemberCard({
             {positionFormatted}
           </p>
           <h3 className="flex items-center">{displayName}{commissionerPill}</h3>
-          <div className="flex-1 flex flex-col items-end pr-6 justify-center">
-            <p className="text-xl rounded-lg bg-green-700 p-2 pr-3 pl-3 font-bold text-white">
-              {underParFormatted}
-            </p>
-          </div>
+          {member.member_sum_under_par !== null && (
+            <div className="flex-1 flex flex-col items-end pr-6 justify-center">
+              <p className="text-xl rounded-lg bg-green-700 p-2 pr-3 pl-3 font-bold text-white">
+                {underParFormatted}
+              </p>
+            </div>
+          )}
         </div>
         <button
           onClick={() => setShowPicks(!showPicks)}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,3 +18,4 @@ export type AppRouter = typeof appRouter;
 export { createContext } from "./context";
 export type { UserContext, CreateContextOptions, Context } from "./context";
 export { autoAdvanceScheduledTournaments } from "./routers/tournament";
+export { autoLockPoolsBeforeTournament } from "./routers/pool";

--- a/packages/api/src/lib/email.ts
+++ b/packages/api/src/lib/email.ts
@@ -334,7 +334,7 @@ export async function sendPoolLockedEmail({
   const content = `
 <h2 style="margin:0 0 16px;color:#181818;font-size:20px;">Picks are locked in!</h2>
 <p style="margin:0 0 8px;color:#333333;font-size:16px;line-height:1.5;">
-  <strong>${poolName}</strong> has been locked by the commissioner.
+  <strong>${poolName}</strong> has been locked.
 </p>
 <p style="margin:0 0 32px;color:#555555;font-size:14px;line-height:1.5;">
   All picks are final. Head over to the pool to see who everyone picked.

--- a/packages/api/src/routers/pool.ts
+++ b/packages/api/src/routers/pool.ts
@@ -74,6 +74,67 @@ export async function autoCompleteStaleLockedPools() {
   });
 }
 
+/**
+ * Auto-locks Open pools whose tournament start_date is today or earlier
+ * in the America/Los_Angeles (Pacific) timezone.
+ * Sends lock notification emails to all pool members.
+ */
+export async function autoLockPoolsBeforeTournament() {
+  // Get today's date in Pacific time
+  const nowPT = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
+  );
+  const todayPT = new Date(
+    nowPT.getFullYear(),
+    nowPT.getMonth(),
+    nowPT.getDate()
+  );
+
+  const poolsToLock = await prisma.pool.findMany({
+    where: {
+      status: "Open",
+      tournament: {
+        start_date: { lte: todayPT },
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      pool_members: {
+        select: { user: { select: { email: true } } },
+      },
+    },
+  });
+
+  if (poolsToLock.length === 0) return [];
+
+  await prisma.pool.updateMany({
+    where: { id: { in: poolsToLock.map((p) => p.id) } },
+    data: { status: "Locked" },
+  });
+
+  const appBaseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  Promise.allSettled(
+    poolsToLock.flatMap((pool) =>
+      pool.pool_members.map((m) =>
+        sendPoolLockedEmail({
+          to: m.user.email,
+          poolName: pool.name,
+          appBaseUrl,
+          poolId: pool.id,
+        })
+      )
+    )
+  ).then((results) => {
+    const failed = results.filter((r) => r.status === "rejected");
+    if (failed.length > 0) {
+      console.error(`Failed to send ${failed.length} auto-lock emails`);
+    }
+  });
+
+  return poolsToLock;
+}
+
 export const poolRouter = router({
   list: protectedProcedure.query(async () => {
     return prisma.pool.findMany({


### PR DESCRIPTION
- Auto-lock Open pools whose tournament starts today or earlier (Pacific time)
- Send lock notification emails to all members when auto-locked
- Update lock email copy to remove "by the commissioner"
- Collapse commissioner panel by default when pool is Locked or Complete
- Hide "Scores last updated" when no actual scores exist
- Hide empty green score bubble when member has no score
- Sync pool members and invites from server props after router.refresh()
- Force server layout re-render after OTP sign-in for immediate logout button