### PR TITLE
feat: allow admins to view any pool

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,14 +3,15 @@ import { InviteActions } from "@/components/pool/InviteActions";
 import { getAuthUser } from "@/lib/supabase/auth";
 
 export default async function HomePage() {
-  const { email } = await getAuthUser();
+  const { email, isAdmin } = await getAuthUser();
 
   if (!email) return null;
 
   const caller = await createServerCaller();
-  const [invites, poolMembers] = await Promise.all([
+  const [invites, poolMembers, allPools] = await Promise.all([
     caller.poolInvite.listPending(),
     caller.poolMember.listByUser(),
+    isAdmin ? caller.pool.list() : Promise.resolve([]),
   ]);
 
   return (
@@ -18,6 +19,8 @@ export default async function HomePage() {
       initialInvites={invites}
       poolMembers={poolMembers}
       userEmail={email}
+      isAdmin={isAdmin}
+      allPools={allPools}
     />
   );
 }

--- a/apps/web/src/app/pool/[id]/page.tsx
+++ b/apps/web/src/app/pool/[id]/page.tsx
@@ -27,8 +27,8 @@ export default async function PoolPage({ params }: PoolPageProps) {
     (member) => member.user_id === supabaseUser.id && member.role === "COMMISSIONER"
   );
 
-  // Non-members and non-commissioners can't see the pool
-  if (!currentUserPoolMember && !isCommissioner) {
+  // Non-members, non-commissioners, and non-admins can't see the pool
+  if (!currentUserPoolMember && !isCommissioner && !isAdmin) {
     redirect("/");
   }
 

--- a/apps/web/src/components/pool/InviteActions.tsx
+++ b/apps/web/src/components/pool/InviteActions.tsx
@@ -48,10 +48,25 @@ interface PoolMembership {
   };
 }
 
+interface AdminPool {
+  id: number;
+  name: string;
+  status: string;
+  amount_entry: number;
+  tournament: {
+    name: string;
+    start_date: Date;
+    end_date: Date;
+    status: string;
+  };
+}
+
 interface InviteActionsProps {
   initialInvites: Invite[];
   poolMembers: PoolMembership[];
   userEmail: string;
+  isAdmin?: boolean;
+  allPools?: AdminPool[];
 }
 
 function phaseColor(phase: PoolPhase) {
@@ -219,6 +234,8 @@ export function InviteActions({
   initialInvites,
   poolMembers,
   userEmail,
+  isAdmin,
+  allPools,
 }: InviteActionsProps) {
   const [poolInvites, setPoolInvites] = useState(initialInvites);
   const [loadingButtonId, setLoadingButtonId] = useState<string | null>(null);
@@ -258,6 +275,11 @@ export function InviteActions({
   const hasActivePools = PHASE_GROUP_ORDER.some(
     (p) => grouped[p] && grouped[p].length > 0
   );
+
+  const memberPoolIds = new Set(poolMembers.map((m) => m.pool.id));
+  const adminOnlyPools = isAdmin && allPools
+    ? allPools.filter((p) => !memberPoolIds.has(p.id))
+    : [];
 
   return (
     <div className="max-w-xl mx-auto w-full px-4 pt-6 pb-8">
@@ -381,6 +403,60 @@ export function InviteActions({
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {/* Admin: all other pools */}
+      {adminOnlyPools.length > 0 && (
+        <div className="mt-6">
+          <div className="mb-2">
+            <span className="text-sm font-semibold px-3 py-1 rounded-full bg-red-100 text-red-700">
+              Admin — All Pools
+            </span>
+          </div>
+          {adminOnlyPools.map((pool) => (
+            <Link
+              key={pool.id}
+              href={`/pool/${pool.id}`}
+              className="block p-4 mb-2 bg-white border border-grey-100 rounded shadow-sm hover:shadow-md transition-shadow group"
+            >
+              <div className="flex items-start justify-between">
+                <div className="min-w-0">
+                  <p className="font-bold text-black">{pool.name}</p>
+                  <p className="text-sm text-grey-75 mt-0.5">
+                    {pool.tournament.name}
+                  </p>
+                </div>
+                <ChevronRight className="w-5 h-5 text-grey-300 group-hover:text-green-700 shrink-0 ml-2 mt-1" />
+              </div>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-xs text-grey-75">
+                <span>
+                  {formatTournamentDates(
+                    pool.tournament.start_date,
+                    pool.tournament.end_date,
+                  )}
+                </span>
+                {pool.amount_entry > 0 && (
+                  <span>${pool.amount_entry} entry</span>
+                )}
+                <span
+                  className={`font-semibold px-2 py-0.5 rounded ${phaseColor(
+                    getEffectivePoolPhase(
+                      pool.status,
+                      resolveTournamentStatus(pool.tournament)
+                    )
+                  )}`}
+                >
+                  {phaseLabel(
+                    getEffectivePoolPhase(
+                      pool.status,
+                      resolveTournamentStatus(pool.tournament)
+                    )
+                  )}
+                </span>
+              </div>
+            </Link>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
- Bypass membership redirect on pool detail page for admins
- Fetch all pools on home page when user is admin
- Show "Admin — All Pools" section for pools the admin isn't a member of