### PR TITLE
fix: handle ESPN linescore stubs for unplayed rounds

### DIFF
--- a/apps/web/src/app/api/scrape/espn-validation.ts
+++ b/apps/web/src/app/api/scrape/espn-validation.ts
@@ -58,14 +58,16 @@ export function validateScoreboardResponse(event: any): ValidationResult {
           `Expected linescore.period to be number, got ${typeof ls.period}`
         );
       }
-      if (typeof ls.value !== "number") {
+      // value and displayValue may be absent for rounds not yet played
+      // (ESPN returns stubs like {"period": 2} for future rounds)
+      if (ls.value !== undefined && typeof ls.value !== "number") {
         errors.push(
-          `Expected linescore.value to be number, got ${typeof ls.value}`
+          `Expected linescore.value to be number or undefined, got ${typeof ls.value}`
         );
       }
-      if (typeof ls.displayValue !== "string") {
+      if (ls.displayValue !== undefined && typeof ls.displayValue !== "string") {
         errors.push(
-          `Expected linescore.displayValue to be string, got ${typeof ls.displayValue}`
+          `Expected linescore.displayValue to be string or undefined, got ${typeof ls.displayValue}`
         );
       }
     }

--- a/apps/web/src/app/api/scrape/tournaments/score-sync.ts
+++ b/apps/web/src/app/api/scrape/tournaments/score-sync.ts
@@ -35,6 +35,8 @@ export function parseScoreToPar(score: string): number | null {
 function getRoundScore(linescores: any[], period: number): number | null {
   const round = linescores.find((ls: any) => ls.period === period);
   if (!round) return null;
+  // ESPN returns value: 0.0 with displayValue: "-" for players who haven't teed off
+  if (!round.displayValue || round.displayValue === "-") return null;
   const value = round.value;
   return typeof value === "number" ? value : null;
 }
@@ -163,8 +165,13 @@ export async function fetchGolfData(id: string) {
     const roundCount = linescores.length;
     const scoreSum = linescores.reduce(
       (sum: number, ls: any) =>
-        typeof ls.value === "number" ? sum + ls.value : sum,
+        typeof ls.value === "number" && ls.displayValue && ls.displayValue !== "-"
+          ? sum + ls.value
+          : sum,
       0
+    );
+    const hasAnyScore = linescores.some(
+      (ls: any) => typeof ls.value === "number" && ls.displayValue && ls.displayValue !== "-"
     );
 
     return {
@@ -177,7 +184,7 @@ export async function fetchGolfData(id: string) {
       score_round_two: getRoundScore(linescores, 2),
       score_round_three: getRoundScore(linescores, 3),
       score_round_four: getRoundScore(linescores, 4),
-      score_sum: roundCount > 0 ? scoreSum : null,
+      score_sum: hasAnyScore ? scoreSum : null,
       status: deriveStatus(roundCount, 4),
     };
   });


### PR DESCRIPTION
## Summary
- ESPN returns stub linescore objects (`{"period": 2}`) with no `value` or `displayValue` for rounds not yet played, and `value: 0.0` with `displayValue: "-"` for players who haven't teed off
- This was causing the cron score sync to fail validation overnight and between rounds, triggering repeated schema alert emails
- Makes validation tolerant of missing `value`/`displayValue` on linescores
- Treats `displayValue: "-"` as no score in `getRoundScore` and `scoreSum` to prevent writing `score_sum: 0` for players who haven't started

## Test plan
- [ ] Deploy and verify cron logs no longer show validation errors during active tournament
- [ ] Confirm scores sync correctly for players mid-round
- [ ] Confirm players who haven't teed off show null scores (not 0)
- [ ] Verify overnight sync doesn't overwrite completed round scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)