### PR TITLE
fix: bypass Next.js fetch cache on all ESPN API calls

### DIFF
--- a/apps/web/src/app/api/scrape/schedule/route.ts
+++ b/apps/web/src/app/api/scrape/schedule/route.ts
@@ -29,7 +29,7 @@ async function fetchEventDetails(
   eventId: string
 ): Promise<{ course: string; city: string; region: string }> {
   try {
-    const response = await fetch(`${ESPN_CORE_API}/${eventId}`);
+    const response = await fetch(`${ESPN_CORE_API}/${eventId}`, { cache: "no-store" });
     if (!response.ok) return { course: "", city: "", region: "" };
 
     const data = await response.json();
@@ -54,7 +54,7 @@ async function fetchEventDetails(
 
 async function fetchSchedule(year: number): Promise<ParsedTournament[]> {
   const url = `${ESPN_SCOREBOARD_API}?dates=${year}0101-${year}1231`;
-  const response = await fetch(url);
+  const response = await fetch(url, { cache: "no-store" });
   if (!response.ok)
     throw new Error(`ESPN API returned ${response.status}`);
 

--- a/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
+++ b/apps/web/src/app/api/scrape/tournaments/[id]/athletes/route.ts
@@ -24,7 +24,7 @@ async function fetchAthleteField(id: string): Promise<Athlete[]> {
     throw new Error("Invalid tournament ID requested.");
 
   const url = `${ESPN_API_BASE}/${tournament.external_id}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { cache: "no-store" });
   if (!response.ok)
     throw new Error(`ESPN API returned ${response.status}`);
 

--- a/apps/web/src/app/api/scrape/tournaments/score-sync.ts
+++ b/apps/web/src/app/api/scrape/tournaments/score-sync.ts
@@ -113,7 +113,7 @@ export async function fetchGolfData(id: string) {
     throw new Error("Invalid tournament ID requested.");
 
   const url = `${ESPN_API_BASE}/${tournament.external_id}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) throw new Error(`ESPN API returned ${response.status}`);
 
   const raw = await response.json();


### PR DESCRIPTION
Next.js Data Cache was caching ESPN responses across cron invocations. The first cron call (before tournament started) cached pre-tournament data (all scores "E", no linescores). Every subsequent cron call got the stale cached response and overwrote real scores with blank data.

Add { cache: "no-store" } to all ESPN fetch calls to ensure fresh data on every request.