### PR TITLE
feat: add player view toggle on pool page

### DIFF
--- a/apps/web/src/components/pool/PlayerCard.tsx
+++ b/apps/web/src/components/pool/PlayerCard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { formatToPar, type AthletePlayerView } from "@pool-picks/utils";
+
+interface PlayerCardProps {
+  athlete: AthletePlayerView;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+export function PlayerCard({ athlete, isExpanded, onToggle }: PlayerCardProps) {
+  const underParFormatted = formatToPar(athlete.score_under_par);
+  const scoreTodayFormatted = formatToPar(athlete.score_today);
+  const isCutOrWD = athlete.status === "CUT" || athlete.status === "WD";
+  const showStatus = isCutOrWD ? athlete.status : "--";
+
+  const thruIsTeeTime =
+    athlete.thru &&
+    (athlete.thru.includes("AM") || athlete.thru.includes("PM"));
+  const thruFormatted = thruIsTeeTime ? null : athlete.thru;
+
+  return (
+    <div
+      className={`w-full mt-4 p-6 pb-2 rounded-lg bg-white border border-grey-100 shadow-sm ${
+        isCutOrWD ? "opacity-60" : ""
+      }`}
+    >
+      <div className="flex items-center pb-4 pt-0">
+        <div className="flex-1 flex items-center">
+          <p className="text-xl mr-4 text-gold font-extrabold">
+            {athlete.position || showStatus}
+          </p>
+          <h3 className="font-semibold flex-1">{athlete.full_name}</h3>
+          <span className="text-xs text-grey-75 bg-grey-200 rounded px-2 py-1 mr-2">
+            {athlete.pickedBy.length}{" "}
+            {athlete.pickedBy.length === 1 ? "pick" : "picks"}
+          </span>
+          {athlete.score_under_par !== null && (
+            <p className="text-xl rounded-lg bg-green-700 p-2 pr-3 pl-3 font-bold text-white mr-2">
+              {underParFormatted}
+            </p>
+          )}
+        </div>
+        <button onClick={onToggle} className="p-1">
+          <svg
+            className={`w-4 h-4 transition-transform text-grey-75 ${
+              isExpanded ? "" : "rotate-180"
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {isExpanded && (
+        <>
+          <div className="flex justify-around bg-grey-200 border border-grey-100 p-4 rounded mb-4">
+            {scoreTodayFormatted && (
+              <div className="flex-1 flex flex-col items-center justify-center">
+                <span className="text-xs text-grey-75">Today</span>
+                <p>{scoreTodayFormatted}</p>
+              </div>
+            )}
+            {thruFormatted && (
+              <div className="flex-1 flex flex-col items-center justify-center">
+                <span className="text-xs text-grey-75">Thru</span>
+                <p>{thruFormatted || "-"}</p>
+              </div>
+            )}
+            {thruIsTeeTime && (
+              <div className="flex-1 flex flex-col items-center justify-center">
+                <span className="text-xs text-grey-75">Tee Time</span>
+                <p>{athlete.thru || "-"}</p>
+              </div>
+            )}
+            <div className="flex-1 flex flex-col items-center justify-center">
+              <span className="text-xs text-grey-75">R1</span>
+              <p>{athlete.score_round_one || "-"}</p>
+            </div>
+            <div className="flex-1 flex flex-col items-center justify-center">
+              <span className="text-xs text-grey-75">R2</span>
+              <p>{athlete.score_round_two || "-"}</p>
+            </div>
+            <div className="flex-1 flex flex-col items-center justify-center">
+              <span className="text-xs text-grey-75">R3</span>
+              <p>{athlete.score_round_three || "-"}</p>
+            </div>
+            <div className="flex-1 flex flex-col items-center justify-center">
+              <span className="text-xs text-grey-75">R4</span>
+              <p>{athlete.score_round_four || "-"}</p>
+            </div>
+          </div>
+
+          <div className="pb-4">
+            <p className="text-xs text-grey-75 mb-2 font-semibold">Picked by</p>
+            {athlete.pickedBy.map((member) => {
+              const posLabel = member.isDQ
+                ? "DQ"
+                : member.memberPosition
+                  ? `${member.isTied ? "T" : ""}${member.memberPosition}`
+                  : "--";
+              const scoreLabel = member.isDQ
+                ? "DQ"
+                : formatToPar(member.memberScore);
+
+              return (
+                <div
+                  key={member.memberId}
+                  className="flex items-center p-2 mb-2 bg-grey-200 border border-grey-100 rounded"
+                >
+                  <p className="text-sm mr-3 text-gold font-extrabold">
+                    {posLabel}
+                  </p>
+                  <p className="flex-1 text-sm font-medium">
+                    {member.displayName}
+                  </p>
+                  {member.role === "COMMISSIONER" && (
+                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gold/20 text-yellow text-[10px] leading-none font-bold mr-2">
+                      C
+                    </span>
+                  )}
+                  {member.memberScore !== null && (
+                    <span className="text-sm font-bold bg-green-700 text-white rounded px-2 py-1">
+                      {scoreLabel}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/pool/PlayerCardList.tsx
+++ b/apps/web/src/components/pool/PlayerCardList.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { AthletePlayerView } from "@pool-picks/utils";
+import { PlayerCard } from "./PlayerCard";
+
+interface PlayerCardListProps {
+  athletes: AthletePlayerView[];
+  expandedIds: Set<number>;
+  onToggle: (id: number) => void;
+}
+
+export function PlayerCardList({ athletes, expandedIds, onToggle }: PlayerCardListProps) {
+  if (athletes.length === 0) {
+    return (
+      <div className="w-full mt-4 p-6 rounded-lg bg-white border border-grey-100 shadow-sm text-center">
+        <p className="text-grey-75 italic">No picks to display</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      {athletes.map((athlete) => (
+        <PlayerCard
+          key={athlete.id}
+          athlete={athlete}
+          isExpanded={expandedIds.has(athlete.id)}
+          onToggle={() => onToggle(athlete.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pool/PoolDetailClient.tsx
+++ b/apps/web/src/components/pool/PoolDetailClient.tsx
@@ -7,12 +7,15 @@ import {
   formatTournamentDates,
   resolveTournamentStatus,
   getEffectivePoolPhase,
+  pivotToPlayerView,
   type PoolMemberFormatted,
 } from "@pool-picks/utils";
 import { trpc } from "@/lib/trpc/client";
 import { PoolStatusCard } from "./PoolStatusCard";
 import { PoolAdminPanel } from "./PoolAdminPanel";
 import { PoolMemberCard } from "./PoolMemberCard";
+import { ViewToggle } from "./ViewToggle";
+import { PlayerCardList } from "./PlayerCardList";
 
 function scoreFingerprint(members: any[]): string {
   return members
@@ -83,6 +86,9 @@ export function PoolDetailClient({
     () => getEffectivePoolPhase(poolStatus, tournamentStatus),
     [poolStatus, tournamentStatus]
   );
+  const [view, setView] = useState<"members" | "players">("members");
+  const [expandedMemberIds, setExpandedMemberIds] = useState<Set<number>>(new Set());
+  const [expandedPlayerIds, setExpandedPlayerIds] = useState<Set<number>>(new Set());
   const [updatedPoolMembers, setUpdatedPoolMembers] =
     useState<PoolMemberFormatted[]>(initialPoolMembers);
   const [poolInvites, setPoolInvites] = useState(pool.pool_invites);
@@ -102,6 +108,13 @@ export function PoolDetailClient({
   const [, setTick] = useState(0);
 
   const isLive = phase === "live";
+  const showViewToggle =
+    phase === "locked-awaiting" || phase === "live" || phase === "completed";
+
+  const playerViewData = useMemo(
+    () => pivotToPlayerView(updatedPoolMembers),
+    [updatedPoolMembers]
+  );
 
   const totalPotAmount = updatedPoolMembers.length * pool.amount_entry;
   const tournamentExternalUrl = pool.tournament.external_id
@@ -261,28 +274,91 @@ export function PoolDetailClient({
         )}
       </div>
 
-      {[...updatedPoolMembers]
-        .sort((a, b) => {
-          if (phase === "open") {
-            const aIsCurrentUser = a.id === currentUserPoolMemberId ? 0 : 1;
-            const bIsCurrentUser = b.id === currentUserPoolMemberId ? 0 : 1;
-            if (aIsCurrentUser !== bIsCurrentUser) return aIsCurrentUser - bIsCurrentUser;
-            const aHasPicks = a.picks?.length ? 0 : 1;
-            const bHasPicks = b.picks?.length ? 0 : 1;
-            return aHasPicks - bHasPicks;
-          }
-          return 0;
-        })
-        .map((member) => (
-          <PoolMemberCard
-            key={member.id}
-            member={member}
-            currentMemberId={currentUserPoolMemberId}
-            phase={phase}
-            tournamentId={pool.tournament.id}
-            tournamentExternalUrl={tournamentExternalUrl}
-          />
-        ))}
+      {showViewToggle && (() => {
+        const membersWithPicks = updatedPoolMembers.filter(m => m.picks?.length);
+        const allMembersExpanded = membersWithPicks.length > 0 && membersWithPicks.every(m => expandedMemberIds.has(m.id));
+        const allPlayersExpanded = playerViewData.length > 0 && expandedPlayerIds.size === playerViewData.length;
+        const allExpanded = view === "players" ? allPlayersExpanded : allMembersExpanded;
+
+        return (
+          <div className="flex items-center justify-between mt-4 w-full">
+            <ViewToggle view={view} onViewChange={setView} />
+            <button
+              onClick={() => {
+                if (view === "players") {
+                  if (allPlayersExpanded) {
+                    setExpandedPlayerIds(new Set());
+                  } else {
+                    setExpandedPlayerIds(new Set(playerViewData.map(a => a.id)));
+                  }
+                } else {
+                  if (allMembersExpanded) {
+                    setExpandedMemberIds(new Set());
+                  } else {
+                    setExpandedMemberIds(new Set(membersWithPicks.map(m => m.id)));
+                  }
+                }
+              }}
+              className="text-xs font-medium text-green-700 hover:text-green-900 transition-colors"
+            >
+              {allExpanded ? "Collapse All" : "Expand All"}
+            </button>
+          </div>
+        );
+      })()}
+
+      {view === "players" && showViewToggle ? (
+        <PlayerCardList
+          athletes={playerViewData}
+          expandedIds={expandedPlayerIds}
+          onToggle={(id) => {
+            setExpandedPlayerIds((prev) => {
+              const next = new Set(prev);
+              if (next.has(id)) {
+                next.delete(id);
+              } else {
+                next.add(id);
+              }
+              return next;
+            });
+          }}
+        />
+      ) : (
+        [...updatedPoolMembers]
+          .sort((a, b) => {
+            if (phase === "open") {
+              const aIsCurrentUser = a.id === currentUserPoolMemberId ? 0 : 1;
+              const bIsCurrentUser = b.id === currentUserPoolMemberId ? 0 : 1;
+              if (aIsCurrentUser !== bIsCurrentUser) return aIsCurrentUser - bIsCurrentUser;
+              const aHasPicks = a.picks?.length ? 0 : 1;
+              const bHasPicks = b.picks?.length ? 0 : 1;
+              return aHasPicks - bHasPicks;
+            }
+            return 0;
+          })
+          .map((member) => (
+            <PoolMemberCard
+              key={member.id}
+              member={member}
+              currentMemberId={currentUserPoolMemberId}
+              phase={phase}
+              tournamentId={pool.tournament.id}
+              tournamentExternalUrl={tournamentExternalUrl}
+              isExpanded={showViewToggle ? expandedMemberIds.has(member.id) : undefined}
+              onToggleExpand={showViewToggle ? () => {
+                setExpandedMemberIds((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(member.id)) {
+                    next.delete(member.id);
+                  } else {
+                    next.add(member.id);
+                  }
+                  return next;
+                });
+              } : undefined}
+            />
+          ))
+      )}
 
       {poolInvites.map((invite) => (
         <div

--- a/apps/web/src/components/pool/PoolMemberCard.tsx
+++ b/apps/web/src/components/pool/PoolMemberCard.tsx
@@ -22,6 +22,8 @@ interface PoolMemberCardProps {
   phase: PoolPhase;
   tournamentId: number;
   tournamentExternalUrl: string | null;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
 }
 
 export function PoolMemberCard({
@@ -30,13 +32,17 @@ export function PoolMemberCard({
   phase,
   tournamentId,
   tournamentExternalUrl,
+  isExpanded,
+  onToggleExpand,
 }: PoolMemberCardProps) {
   const currentUserCard = member.id === currentMemberId;
   const pickStatus = member.picks?.length
     ? "Picks Submitted"
     : "Awaiting Picks";
 
-  const [showPicks, setShowPicks] = useState(false);
+  const [showPicksLocal, setShowPicksLocal] = useState(false);
+  const showPicks = isExpanded !== undefined ? isExpanded : showPicksLocal;
+  const setShowPicks = onToggleExpand || (() => setShowPicksLocal((prev) => !prev));
   const [isEditingPicks, setIsEditingPicks] = useState(false);
   const [hasSubmittedUsername, setHasSubmittedUsername] = useState(
     !!member.username
@@ -192,7 +198,7 @@ export function PoolMemberCard({
           )}
         </div>
         <button
-          onClick={() => setShowPicks(!showPicks)}
+          onClick={() => onToggleExpand ? onToggleExpand() : setShowPicksLocal((prev) => !prev)}
           className="p-1"
         >
           <svg

--- a/apps/web/src/components/pool/ViewToggle.tsx
+++ b/apps/web/src/components/pool/ViewToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+type View = "members" | "players";
+
+interface ViewToggleProps {
+  view: View;
+  onViewChange: (view: View) => void;
+}
+
+export function ViewToggle({ view, onViewChange }: ViewToggleProps) {
+  return (
+    <div className="flex items-center bg-grey-200 rounded-full p-0.5">
+      <button
+        onClick={() => onViewChange("members")}
+        className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
+          view === "members"
+            ? "bg-white text-black shadow-sm"
+            : "text-grey-75 hover:text-black"
+        }`}
+      >
+        Pool Members
+      </button>
+      <button
+        onClick={() => onViewChange("players")}
+        className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
+          view === "players"
+            ? "bg-white text-black shadow-sm"
+            : "text-grey-75 hover:text-black"
+        }`}
+      >
+        Players Picked
+      </button>
+    </div>
+  );
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,8 +2,13 @@ export {
   sumMemberPicks,
   reformatPoolMembers,
   calculateMemberPosition,
+  pivotToPlayerView,
 } from "./scoring";
-export type { PoolMemberFormatted, AthletePickFormatted } from "./scoring";
+export type {
+  PoolMemberFormatted,
+  AthletePickFormatted,
+  AthletePlayerView,
+} from "./scoring";
 
 export {
   formatToPar,

--- a/packages/utils/src/scoring.ts
+++ b/packages/utils/src/scoring.ts
@@ -34,6 +34,68 @@ export interface AthletePickFormatted {
   tournament_id: number | null;
 }
 
+export interface AthletePlayerView extends AthletePickFormatted {
+  pickedBy: {
+    memberId: number;
+    displayName: string;
+    memberPosition?: number;
+    memberScore: number | null;
+    isTied?: boolean;
+    isDQ?: boolean;
+    role?: string;
+  }[];
+}
+
+export function pivotToPlayerView(
+  members: PoolMemberFormatted[]
+): AthletePlayerView[] {
+  const athleteMap = new Map<number, AthletePlayerView>();
+
+  for (const member of members) {
+    const displayName = member.username || member.nickname || "Unknown";
+    for (const pick of member.picks) {
+      const memberInfo = {
+        memberId: member.id,
+        displayName,
+        memberPosition: member.member_position,
+        memberScore: member.member_sum_under_par,
+        isTied: member.isTied,
+        isDQ: member.isDQ,
+        role: member.role,
+      };
+
+      const existing = athleteMap.get(pick.id);
+      if (existing) {
+        existing.pickedBy.push(memberInfo);
+      } else {
+        athleteMap.set(pick.id, {
+          ...pick,
+          pickedBy: [memberInfo],
+        });
+      }
+    }
+  }
+
+  return Array.from(athleteMap.values())
+    .map((athlete) => ({
+      ...athlete,
+      pickedBy: [...athlete.pickedBy].sort((a, b) => {
+        if (a.memberPosition !== undefined && b.memberPosition !== undefined)
+          return a.memberPosition - b.memberPosition;
+        if (a.memberPosition !== undefined) return -1;
+        if (b.memberPosition !== undefined) return 1;
+        return 0;
+      }),
+    }))
+    .sort((a, b) => {
+      if (a.score_under_par !== null && b.score_under_par !== null)
+        return a.score_under_par - b.score_under_par;
+      if (a.score_under_par !== null) return -1;
+      if (b.score_under_par !== null) return 1;
+      return a.full_name.localeCompare(b.full_name);
+    });
+}
+
 export function sumMemberPicks(athleteData: AthletePickData[]): number | null {
   const validPicks = athleteData
     .filter((pick) => pick.status === "Active")


### PR DESCRIPTION
## Summary
- Adds a "Pool Members" / "Players Picked" view toggle on locked/live/completed pool pages
- **Players Picked view**: cards grouped by athlete showing position, score, round details, and which pool members picked them — sorted by leaderboard position
- **Expand All / Collapse All** button works for both views, displayed inline with the toggle
- No new API calls — pivots existing pool member data client-side via `pivotToPlayerView()` utility
- Compact pill-style toggle to keep it unobtrusive

## Test plan
- [ ] Navigate to a locked/active/completed pool with multiple members
- [ ] Verify toggle appears between header and cards
- [ ] Switch to "Players Picked" — confirm athletes sorted by position, expand shows "Picked by" list
- [ ] Expand All / Collapse All works in both views
- [ ] Switch back to "Pool Members" — everything works as before
- [ ] Toggle does NOT appear on open/setup phase pools
- [ ] In live phase, confirm 30s polling updates both views correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)