### PR TITLE
feat: auto-populate cut line and CUT/WD status from ESPN core API

### DIFF
--- a/apps/web/src/app/api/scrape/espn-validation.ts
+++ b/apps/web/src/app/api/scrape/espn-validation.ts
@@ -144,6 +144,35 @@ export function validateScheduleResponse(data: any): ValidationResult {
   return { valid: errors.length === 0, errors };
 }
 
+export function validateCoreEventResponse(event: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof event?.id !== "string") {
+    errors.push(`Expected event.id to be string, got ${typeof event?.id}`);
+  }
+  if (typeof event?.tournament?.$ref !== "string") {
+    errors.push("Missing: event.tournament.$ref");
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateCoreTournamentResponse(data: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof data?.cutRound !== "number") {
+    errors.push(`Expected cutRound to be number, got ${typeof data?.cutRound}`);
+  }
+  if (typeof data?.cutScore !== "number") {
+    errors.push(`Expected cutScore to be number, got ${typeof data?.cutScore}`);
+  }
+  if (typeof data?.cutCount !== "number") {
+    errors.push(`Expected cutCount to be number, got ${typeof data?.cutCount}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
 export function validateEventDetailsResponse(data: any): ValidationResult {
   const errors: string[] = [];
 

--- a/apps/web/src/app/api/scrape/tournaments/score-sync.ts
+++ b/apps/web/src/app/api/scrape/tournaments/score-sync.ts
@@ -1,11 +1,100 @@
 import { prisma } from "@pool-picks/db";
 import {
   assertValidResponse,
+  validateCoreEventResponse,
+  validateCoreTournamentResponse,
   validateScoreboardResponse,
 } from "../espn-validation";
 
 const ESPN_API_BASE =
   "https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard";
+const ESPN_CORE_BASE =
+  "https://sports.core.api.espn.com/v2/sports/golf/leagues/pga";
+
+// ESPN uses `STATUS_CUT` as the type for CUT, WD, and DQ; displayValue disambiguates.
+// We collapse non-CUT variants to "WD" so downstream scoring/UI doesn't need to change.
+function mapCoreStatus(typeName: string, displayValue: string): string {
+  if (typeName !== "STATUS_CUT") return "Active";
+  return displayValue === "CUT" ? "CUT" : "WD";
+}
+
+interface CutData {
+  cutRound: number;
+  cutScore: number | null; // null when cutRound === 0 (cut not yet applied / no cut event)
+  cutCount: number;
+}
+
+// Fetches tournament-level cut data via the core API.
+// Throws on network/schema errors — the schema validator fires admin alerts.
+async function fetchCutData(externalEventId: number): Promise<CutData> {
+  const eventRes = await fetch(
+    `${ESPN_CORE_BASE}/events/${externalEventId}`,
+    { cache: "no-store" }
+  );
+  if (!eventRes.ok) {
+    throw new Error(`ESPN core event API returned ${eventRes.status}`);
+  }
+  const event = await eventRes.json();
+  await assertValidResponse(event, validateCoreEventResponse, "core event");
+
+  const tournamentRes = await fetch(event.tournament.$ref, {
+    cache: "no-store",
+  });
+  if (!tournamentRes.ok) {
+    throw new Error(
+      `ESPN core tournament API returned ${tournamentRes.status}`
+    );
+  }
+  const tournament = await tournamentRes.json();
+  await assertValidResponse(
+    tournament,
+    validateCoreTournamentResponse,
+    "core tournament"
+  );
+
+  return {
+    cutRound: tournament.cutRound,
+    cutScore: tournament.cutRound > 0 ? tournament.cutScore : null,
+    cutCount: tournament.cutCount,
+  };
+}
+
+// Fetches per-competitor status in parallel batches. Tolerates individual failures
+// so a single 404 or timeout doesn't fail the whole sync — existing DB CUT/WD
+// statuses are preserved in updateGolfData when the map is missing an entry.
+async function fetchCompetitorStatuses(
+  externalEventId: number,
+  competitorIds: string[]
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  const BATCH_SIZE = 20;
+
+  for (let i = 0; i < competitorIds.length; i += BATCH_SIZE) {
+    const batch = competitorIds.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (id) => {
+        const url = `${ESPN_CORE_BASE}/events/${externalEventId}/competitions/${externalEventId}/competitors/${id}/status`;
+        try {
+          const res = await fetch(url, { cache: "no-store" });
+          if (!res.ok) return;
+          const data = await res.json();
+          const typeName = data?.type?.name;
+          const displayValue = data?.displayValue;
+          if (
+            typeof typeName === "string" &&
+            typeof displayValue === "string"
+          ) {
+            result.set(id, mapCoreStatus(typeName, displayValue));
+          }
+        } catch {
+          // tolerate individual failures
+        }
+      })
+    );
+  }
+
+  return result;
+}
 
 export interface ParsedAthleteData {
   full_name: string;
@@ -128,7 +217,6 @@ export async function fetchGolfData(id: string) {
 
   const parsedAthleteData: ParsedAthleteData[] = competitors.map((c: any) => {
     const linescores = c.linescores || [];
-    const roundCount = linescores.length;
     const scoreSum = linescores.reduce(
       (sum: number, ls: any) =>
         typeof ls.value === "number" && ls.displayValue && ls.displayValue !== "-"
@@ -155,7 +243,23 @@ export async function fetchGolfData(id: string) {
     };
   });
 
-  return { parsedAthleteData };
+  // Pull cut data from the core API. Once the cut is set, also fetch per-competitor
+  // status so we can mark CUT/WD from ESPN instead of deriving from a score threshold.
+  const cutData = await fetchCutData(tournament.external_id);
+
+  if (cutData.cutRound > 0) {
+    const competitorIds = competitors.map((c: any) => String(c.id));
+    const statusMap = await fetchCompetitorStatuses(
+      tournament.external_id,
+      competitorIds
+    );
+    competitors.forEach((c: any, i: number) => {
+      const mapped = statusMap.get(String(c.id));
+      if (mapped) parsedAthleteData[i].status = mapped;
+    });
+  }
+
+  return { parsedAthleteData, cutScore: cutData.cutScore };
 }
 
 interface ScoreFields {
@@ -192,13 +296,28 @@ function scoreFieldsChanged(
 export async function updateGolfData(
   {
     parsedAthleteData,
+    cutScore,
   }: {
     parsedAthleteData: ParsedAthleteData[];
+    cutScore: number | null;
   },
   tournamentId: number
 ): Promise<{ hasChanges: boolean }> {
   if (!parsedAthleteData.length)
     throw new Error("No data available for this tournament!");
+
+  // Mirror ESPN's cut line onto the tournament row. Null before the cut is applied;
+  // populated once ESPN sets it. Also cleared for signature/no-cut events.
+  const existingTournament = await prisma.tournament.findUnique({
+    where: { id: tournamentId },
+    select: { cut_line: true },
+  });
+  if (existingTournament && existingTournament.cut_line !== cutScore) {
+    await prisma.tournament.update({
+      where: { id: tournamentId },
+      data: { cut_line: cutScore },
+    });
+  }
 
   // Fetch existing scores to compare against
   const existingRecords = await prisma.athletesInTournaments.findMany({
@@ -228,7 +347,8 @@ export async function updateGolfData(
           score_today: athleteData.score_today,
           position: athleteData.position,
           thru: athleteData.thru,
-          // Preserve CUT/WD status — these are set by cut_line logic, not ESPN
+          // Preserve CUT/WD once set — a status fetch can fail for an individual
+          // competitor, and a player can't un-cut. Transitions are monotonic.
           status:
             existing && (existing.status === "CUT" || existing.status === "WD")
               ? existing.status
@@ -262,27 +382,6 @@ export async function updateGolfData(
         }
       })
     );
-  }
-
-  // Apply commissioner-set cut line: mark players above cut as "CUT"
-  // Only targets Active players with R2 complete but no R3 score yet
-  const tournamentRecord = await prisma.tournament.findUnique({
-    where: { id: tournamentId },
-    select: { cut_line: true },
-  });
-
-  if (tournamentRecord?.cut_line != null) {
-    const cutResult = await prisma.athletesInTournaments.updateMany({
-      where: {
-        tournament_id: tournamentId,
-        status: "Active",
-        score_round_two: { not: null },
-        score_round_three: null,
-        score_under_par: { gt: tournamentRecord.cut_line },
-      },
-      data: { status: "CUT", updated_at: new Date() },
-    });
-    rowsWritten += cutResult.count;
   }
 
   const hasChanges = rowsWritten > 0;


### PR DESCRIPTION
## Summary
- Replaces the commissioner-driven cut_line DB edit + score-threshold heuristic with a direct mirror of ESPN's **core API** cut data.
- Each sync fetches `cutScore` / `cutRound` / `cutCount` from `sports.core.api.espn.com/.../tournaments/{tid}/seasons/{year}` via the `event.tournament.$ref` and mirrors `cutScore` into `Tournament.cut_line`.
- Once `cutRound > 0`, per-competitor status (`STATUS_CUT` + `displayValue`) is fetched in batched-parallel and mapped to our existing `"CUT"` / `"WD"` convention — no more guessing CUTs from a score threshold, and WDs are now detected automatically.
- Adds `validateCoreEventResponse` and `validateCoreTournamentResponse` so ESPN shape changes fire the existing admin alert email.
- Deletes the threshold-based CUT marking block; keeps the monotonic CUT/WD preservation as a safety net for individual status-fetch failures.

## Behavior
- **R1 / mid-R2** (`cutRound: 0`) → `cut_line` stays null, all athletes Active, no per-competitor fetches.
- **Cut applied** (`cutRound: 2`) → next sync writes `cutScore` → `cut_line`, marks CUT/WD from ESPN statuses.
- **Signature / no-cut events** → ESPN reports `0/0/0` → `cut_line` stays null, nothing marked. Correct by default.
- **DQ logic** in `scoring.ts` is already driven by pick statuses → triggers automatically once CUT propagates.

## Test plan
- [ ] Run a score sync on a past tournament — verify `cut_line` matches ESPN and CUT/WD statuses populate.
- [ ] Run a score sync on a signature event (e.g. RBC Heritage 2026) — verify `cut_line` stays null.
- [ ] Run a score sync on a live tournament pre-cut — verify `cut_line` stays null and no athletes are marked CUT.
- [ ] Temporarily break a core API response shape (e.g. rename `cutScore`) — verify the admin alert email fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)