### PR TITLE
feat: Excluded tournament status + dedupe schema-change alert emails

### DIFF
--- a/apps/web/src/app/api/scrape/espn-validation.ts
+++ b/apps/web/src/app/api/scrape/espn-validation.ts
@@ -1,8 +1,16 @@
 import { Resend } from "resend";
+import { prisma } from "@pool-picks/db";
 
 interface ValidationResult {
   valid: boolean;
   errors: string[];
+}
+
+// Returns midnight UTC for the given date — matches Prisma @db.Date column
+// semantics so the (endpoint, alert_date) unique index collapses all same-day
+// failures to a single row.
+function startOfUTCDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
 }
 
 // --- Validators ---
@@ -218,6 +226,25 @@ export async function sendSchemaAlert(
       "Cannot send schema alert — ADMIN_ALERT_EMAIL or RESEND_API_KEY not set"
     );
     return;
+  }
+
+  // Dedupe: at most one email per endpoint per UTC day. Insert first; if the
+  // unique (endpoint, alert_date) constraint fires we've already alerted today.
+  try {
+    await prisma.schemaAlert.create({
+      data: {
+        endpoint,
+        alert_date: startOfUTCDay(new Date()),
+      },
+    });
+  } catch (err: any) {
+    if (err?.code === "P2002") {
+      // Already alerted today — skip the Resend send.
+      return;
+    }
+    // Any other DB error: log and fall through. A duplicate email beats silence
+    // when the database is flaking and we can't tell if we've alerted yet.
+    console.error("SchemaAlert dedupe write failed:", err);
   }
 
   try {

--- a/apps/web/src/app/api/scrape/tournaments/score-sync.ts
+++ b/apps/web/src/app/api/scrape/tournaments/score-sync.ts
@@ -177,7 +177,7 @@ export async function fetchGolfData(id: string) {
   await assertValidResponse(
     event,
     validateScoreboardResponse,
-    "scoreboard (scores)"
+    `scoreboard (scores) #${tournament.id}`
   );
 
   if (event.id !== String(tournament.external_id)) {

--- a/apps/web/src/app/system-admin/tournament/[id]/page.tsx
+++ b/apps/web/src/app/system-admin/tournament/[id]/page.tsx
@@ -78,11 +78,11 @@ export default function TournamentAdminPage() {
     setSelectedOption(option);
     updateTournament.mutate({
       id: tournament.id,
-      status: option.value as "Scheduled" | "Active" | "Completed",
+      status: option.value as "Scheduled" | "Active" | "Completed" | "Excluded",
     });
   };
 
-  const tournamentStatuses = ["Scheduled", "Active", "Completed"];
+  const tournamentStatuses = ["Scheduled", "Active", "Completed", "Excluded"];
   const selectOptions: SelectValues[] = tournamentStatuses.map((el) => ({
     value: el,
     label: el,
@@ -153,6 +153,11 @@ export default function TournamentAdminPage() {
           >
             Score Auto-Sync: {resolvedStatus === "Active" ? "ON" : "OFF"}
           </span>
+          {resolvedStatus === "Excluded" && (
+            <span className="inline-block text-xs font-medium px-2 py-1 rounded mt-1 ml-2 bg-grey-100 text-grey-75">
+              Excluded — hidden from pool creation, skipped by cron
+            </span>
+          )}
           {tournamentHealth.data && (
             <div className="flex gap-3 mt-2">
               <span

--- a/apps/web/src/components/admin/TournamentList.tsx
+++ b/apps/web/src/components/admin/TournamentList.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { formatTournamentDates, resolveTournamentStatus, getTournamentStatus } from "@pool-picks/utils";
+import { formatTournamentDates, resolveTournamentStatus } from "@pool-picks/utils";
 import { SyncScheduleButton } from "./SyncScheduleButton";
 
 interface Pool {
@@ -28,6 +28,8 @@ function statusColor(status: string) {
     case "Active":
       return "bg-green-100 text-green-700";
     case "Completed":
+      return "bg-grey-100 text-grey-75";
+    case "Excluded":
       return "bg-grey-100 text-grey-75";
     default:
       return "bg-yellow/20 text-yellow";
@@ -211,7 +213,7 @@ function TournamentCard({
 }) {
   const [pastOpen, setPastOpen] = useState(false);
 
-  const displayStatus = getTournamentStatus(tournament.start_date, tournament.end_date);
+  const displayStatus = resolveTournamentStatus(tournament);
 
   return (
     <li className="bg-white border border-grey-100 rounded-lg shadow-sm p-3 mb-2">

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -86,7 +86,10 @@ export const tournamentRouter = router({
 
   listSelectable: protectedProcedure.query(async () => {
     return prisma.tournament.findMany({
-      where: { end_date: { gte: new Date() } },
+      where: {
+        end_date: { gte: new Date() },
+        status: { notIn: ["Excluded", "Completed"] },
+      },
       orderBy: { start_date: "asc" },
       select: {
         id: true,
@@ -120,7 +123,7 @@ export const tournamentRouter = router({
     .input(
       z.object({
         id: z.number(),
-        status: z.enum(["Scheduled", "Active", "Completed"]),
+        status: z.enum(["Scheduled", "Active", "Completed", "Excluded"]),
       })
     )
     .mutation(async ({ input }) => {

--- a/packages/db/prisma/migrations/20260423000000_add_schema_alert_dedupe/migration.sql
+++ b/packages/db/prisma/migrations/20260423000000_add_schema_alert_dedupe/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "SchemaAlert" (
+    "id" SERIAL NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "alert_date" DATE NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SchemaAlert_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SchemaAlert_endpoint_alert_date_key" ON "SchemaAlert"("endpoint", "alert_date");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -126,3 +126,12 @@ model PoolMembersAthletes {
 
   @@id([poolMember_id, athlete_id])
 }
+
+model SchemaAlert {
+  id         Int      @id @default(autoincrement())
+  endpoint   String
+  alert_date DateTime @db.Date
+  created_at DateTime @default(now())
+
+  @@unique([endpoint, alert_date])
+}

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -5,7 +5,12 @@ export const MAX_A_GROUP_PICKS = 3;
 export const POOL_STATUSES = ["Setup", "Open", "Locked", "Complete"] as const;
 export type PoolStatus = (typeof POOL_STATUSES)[number];
 
-export const TOURNAMENT_STATUSES = ["Scheduled", "Active", "Completed"] as const;
+export const TOURNAMENT_STATUSES = [
+  "Scheduled",
+  "Active",
+  "Completed",
+  "Excluded",
+] as const;
 export type TournamentStatus = (typeof TOURNAMENT_STATUSES)[number];
 
 export const INVITE_STATUSES = ["Invited", "Accepted", "Rejected"] as const;

--- a/packages/utils/src/tournamentStatus.test.ts
+++ b/packages/utils/src/tournamentStatus.test.ts
@@ -165,4 +165,19 @@ describe("resolveTournamentStatus", () => {
       })
     ).toBe("Active");
   });
+
+  it("respects Excluded status even when start_date has passed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(utcDate(2026, 4, 12)); // Mid-tournament
+
+    // Excluded means the admin manually turned off auto-sync for this tournament
+    // (e.g. Pro-Am format that breaks ESPN validator). Must not auto-advance.
+    expect(
+      resolveTournamentStatus({
+        start_date: utcDate(2026, 4, 10),
+        end_date: utcDate(2026, 4, 13),
+        status: "Excluded",
+      })
+    ).toBe("Excluded");
+  });
 });

--- a/packages/utils/src/tournamentStatus.ts
+++ b/packages/utils/src/tournamentStatus.ts
@@ -46,7 +46,8 @@ export function resolveTournamentStatus(tournament: {
   end_date: Date;
   status: string;
 }): TournamentStatus {
-  // Completed and Active are always respected — admin set them explicitly
+  // Admin-set terminal/suspended statuses are always respected — never auto-advance
+  if (tournament.status === "Excluded") return "Excluded";
   if (tournament.status === "Completed") return "Completed";
   if (tournament.status === "Active") return "Active";
 


### PR DESCRIPTION
## Summary

- **Excluded** — a new fourth tournament status. Admins can flip a tournament to Excluded to stop auto-sync (cron skips `status != "Active"`) and hide it from pool creation, without misrepresenting it as Completed. Immediate use case: the current Pro-Am, whose two-athletes-per-line format breaks `validateScoreboardResponse` and is currently firing ~100 alert emails per night.
- **Alert dedupe** — new `SchemaAlert` table with a unique `(endpoint, alert_date)` index. `sendSchemaAlert` inserts first and skips the Resend send on `P2002`, so at most one email per endpoint per UTC day. Scoreboard endpoint label now includes the tournament id so per-tournament breakages each get their own dedupe bucket.
- Auto-sync behavior is unchanged for Scheduled/Active/Completed; the cron and auto-advance already key off `status: "Active"`.

## Test plan

- [x] `yarn build` — clean across all packages
- [x] `vitest run` in `packages/utils` — 23/23 passing, including new `resolveTournamentStatus` case for Excluded
- [x] Migration applied to local DB via `prisma migrate deploy`
- [ ] In prod: flip the Pro-Am tournament to Excluded via the admin dropdown; confirm no more schema-change emails
- [ ] Visit `/pool/create` — Excluded tournaments should not appear in the picker
- [ ] Visit `/system-admin/tournament/<excluded-id>` — dropdown shows "Excluded", "Score Auto-Sync: OFF" badge, new "Excluded — hidden from pool creation, skipped by cron" badge, no manual scrape buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)